### PR TITLE
Redo questions db

### DIFF
--- a/mysql scripts/table_creation/appointmentDB.sql
+++ b/mysql scripts/table_creation/appointmentDB.sql
@@ -8,10 +8,10 @@ DROP TABLE IF EXISTS Appointment;
 DROP TABLE IF EXISTS Client;
 DROP TABLE IF EXISTS Location;
 DROP TABLE IF EXISTS PossibleAnswer;
-DROP TABLE IF EXISTS Question;
+DROP TABLE IF EXISTS LitmusQuestion;
 
-CREATE TABLE Question (
-	questionId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+CREATE TABLE LitmusQuestion (
+	litmusQuestionId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
     string VARCHAR(255) NOT NULL,
 	orderIndex INTEGER NOT NULL,
     tag VARCHAR(255) NOT NULL,
@@ -25,8 +25,8 @@ CREATE TABLE PossibleAnswer (
     string VARCHAR(255) NOT NULL,
     orderIndex INTEGER NOT NULL,
     archived BOOLEAN DEFAULT FALSE,
-    questionId INTEGER NOT NULL,
-    FOREIGN KEY (questionId) REFERENCES Question(questionId)
+    litmusQuestionId INTEGER NOT NULL,
+    FOREIGN KEY (litmusQuestionId) REFERENCES LitmusQuestion(litmusQuestionId)
 );
 
 CREATE TABLE Location (
@@ -60,7 +60,7 @@ CREATE TABLE Answer (
     FOREIGN KEY (possibleAnswerId) REFERENCES PossibleAnswer(possibleAnswerId),
     appointmentId INTEGER NOT NULL,
     FOREIGN KEY (appointmentId) REFERENCES Appointment(appointmentId),
-    questionId INTEGER NOT NULL,
-    FOREIGN KEY (questionId) REFERENCES Question(questionId),
+    litmusQuestionId INTEGER NOT NULL,
+    FOREIGN KEY (litmusQuestionId) REFERENCES LitmusQuestion(litmusQuestionId),
     createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/mysql scripts/table_creation/appointmentDB.sql
+++ b/mysql scripts/table_creation/appointmentDB.sql
@@ -5,35 +5,25 @@ USE vita;
 
 DROP TABLE IF EXISTS Answer;
 DROP TABLE IF EXISTS Appointment;
+DROP TABLE IF EXISTS Client;
 DROP TABLE IF EXISTS Location;
 DROP TABLE IF EXISTS PossibleAnswer;
 DROP TABLE IF EXISTS Question;
-DROP TABLE IF EXISTS QuestionInformation;
-
-CREATE TABLE QuestionInformation (
-	questionInformationId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
-    inputType VARCHAR(255) NOT NULL,
-    placeholder VARCHAR(255) NOT NULL,
-    subheading VARCHAR(255) NOT NULL,
-    validationType VARCHAR(255),
-    hint VARCHAR(255),
-    errorMessage VARCHAR(255)
-);
 
 CREATE TABLE Question (
 	questionId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
     string VARCHAR(255) NOT NULL,
+	orderIndex INTEGER NOT NULL,
     tag VARCHAR(255) NOT NULL,
     required BOOLEAN DEFAULT TRUE,
     archived BOOLEAN DEFAULT FALSE,
-    questionInformationId INTEGER NOT NULL,
-    FOREIGN KEY (questionInformationId) REFERENCES QuestionInformation(questionInformationId),
-	CONSTRAINT uniqueTag unique index(tag)
+	CONSTRAINT uniqueTag UNIQUE INDEX(tag)
 );
 
 CREATE TABLE PossibleAnswer (
 	possibleAnswerId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
     string VARCHAR(255) NOT NULL,
+    orderIndex INTEGER NOT NULL,
     archived BOOLEAN DEFAULT FALSE,
     questionId INTEGER NOT NULL,
     FOREIGN KEY (questionId) REFERENCES Question(questionId)
@@ -45,9 +35,18 @@ CREATE TABLE Location (
     address VARCHAR(255)
 );
 
+CREATE TABLE Client (
+	clientId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    firstName VARCHAR(255) NOT NULL,
+    lastName VARCHAR(255) NOT NULL,
+    emailAddress VARCHAR(255) NOT NULL
+);
+
 CREATE TABLE Appointment (
 	appointmentId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
     scheduledTime DATETIME NOT NULL,
+    clientId INTEGER NOT NULL,
+    FOREIGN KEY (clientId) REFERENCES Client(clientId),
     locationId INTEGER NOT NULL,
     FOREIGN KEY (locationId) REFERENCES Location(locationId),
     createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -56,7 +55,8 @@ CREATE TABLE Appointment (
 
 CREATE TABLE Answer (
 	answerId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
-	string VARCHAR(255) NOT NULL,
+	possibleAnswerId INTEGER NOT NULL,
+    FOREIGN KEY (possibleAnswerId) REFERENCES PossibleAnswer(possibleAnswerId),
     appointmentId INTEGER NOT NULL,
     FOREIGN KEY (appointmentId) REFERENCES Appointment(appointmentId),
     questionId INTEGER NOT NULL,

--- a/mysql scripts/table_creation/appointmentDB.sql
+++ b/mysql scripts/table_creation/appointmentDB.sql
@@ -39,7 +39,8 @@ CREATE TABLE Client (
 	clientId INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
     firstName VARCHAR(255) NOT NULL,
     lastName VARCHAR(255) NOT NULL,
-    emailAddress VARCHAR(255) NOT NULL
+    emailAddress VARCHAR(255) NOT NULL,
+    languages VARCHAR(255)
 );
 
 CREATE TABLE Appointment (

--- a/mysql scripts/test_data/appointmentDBTestData.sql
+++ b/mysql scripts/test_data/appointmentDBTestData.sql
@@ -1,153 +1,93 @@
 USE vita;
 
 -- sample questions with choices, if applicable
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("text", "First Name", "Contact Information", NULL, NULL, NULL);
+INSERT INTO Question (string, orderIndex, tag)
+	VALUES ("Are you a phamacist?", 1, "pharmacist");
     
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("First Name", "first_name", TRUE, 
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE placeholder="First Name"));
-
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("text", "Last Name", "Contact Information", NULL, NULL, NULL);
+INSERT INTO Question (string, orderIndex, tag)
+	VALUES ("How often do you gamble?", 2, "gamble");
     
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Last Name", "last_name", TRUE,
-	(SELECT questionInformationId FROM QuestionInformation
-		WHERE placeholder="Last Name"));
+INSERT INTO Question (string, orderIndex, tag)
+	VALUES ("Indicate your military status", 3, "military_status");
     
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("email", "example@example.com", "Contact Information", "email", NULL, NULL);
-    
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Email Address", "email", TRUE,
-	(SELECT questionInformationId FROM QuestionInformation
-		WHERE placeholder="example@example.com"));
-    
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("text", "402-555-1234", "Contact Information", "phoneUS", NULL, NULL);
-    
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Phone Number", "phone_number", FALSE,
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE placeholder="402-555-1234"));
-	
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("select", "No", "Background Information", NULL, NULL, NULL);
-    
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Are you a pharmacist?", "pharmacist", FALSE,
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE inputType="select" AND placeholder="No" AND subheading="Background Information"));
-	
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("select", "Never", "Background Information", NULL, NULL, NULL);
-    
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("How often do you gamble?", "gamble", FALSE, 
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE inputType="select" AND placeholder="Never" AND subheading="Background Information"));
-    
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("select", "None", "Background Information", NULL, NULL, NULL);
-    
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Indicate your military status", "military_status", FALSE,
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE inputType="select" AND placeholder="None" AND subheading="Background Information"));
-        
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("select", "Yes", "Language Information", NULL, NULL, NULL);
-
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("Can you speak fluent English?", "fluent_english", TRUE,
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE inputType="select" AND placeholder="Yes" AND subheading="Language Information"));
-
-INSERT INTO QuestionInformation (inputType, placeholder, subheading, validationType, hint, errorMessage)
-	VALUES ("text", "Spanish, German, French, etc.", "Language Information", NULL, NULL, NULL);
-
-INSERT INTO Question (string, tag, required, questionInformationId) 
-	VALUES ("If no, what is your strongest language?", "strongest_language", FALSE,
-    (SELECT questionInformationId FROM QuestionInformation
-		WHERE inputType="text" AND placeholder="Spanish, German, French, etc." AND subheading="Language Information"));
+INSERT INTO Question (string, orderIndex, tag)
+	VALUES ("Can you speak fluent English?", 4, "fluent_english");
     
 -- Sample Possible Answer data
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Yes", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Yes", 1,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="pharmacist"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("No", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("No", 2,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="pharmacist"));
 	
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Frequently", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Frequently", 1,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Occasionally", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Occasionally", 2,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Rarely", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Rarely", 3,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Never", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Never", 4,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="gamble"));
 	
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Active Duty", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Active Duty", 1,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Active Reserve", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Active Reserve", 2,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Disabled Veterans", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Disabled Veterans", 3,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Inactive Reserve", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Inactive Reserve", 4,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("None", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("None", 5,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="military_status"));
 	
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("Yes", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("Yes", 1,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="fluent_english"));
 		
-INSERT INTO PossibleAnswer (string, questionId) 
-	VALUES ("No", 
+INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+	VALUES ("No", 2,
 	(SELECT questionId 
 		FROM Question 
 		WHERE tag="fluent_english"));
@@ -173,211 +113,134 @@ INSERT INTO Location (title, address)
 
 -- sample appointment with answers
 
+INSERT INTO Client (firstName, lastName, emailAddress)
+	VALUES ("Test", "McTesterson", "test_mctesterson@test.test");
+SET @clientId = LAST_INSERT_ID();
+
 SET @appointmentTime = DATE_ADD(NOW(), INTERVAL 2 HOUR);
 
-INSERT INTO Appointment (scheduledTime, locationId)
-	VALUES (@appointmentTime, 1);
+INSERT INTO Appointment (scheduledTime, clientId, locationId)
+	VALUES (@appointmentTime, @clientId, 1);
 
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("Test",
-    (SELECT appointmentId
-		FROM Appointment
-        WHERE scheduledTime=@appointmentTime AND locationId=1),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="first_name"));
-            
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("McTesterson",
-    (SELECT appointmentId
-		FROM Appointment
-        WHERE scheduledTime=@appointmentTime AND locationId=1),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="last_name"));
+
+INSERT INTO Client (firstName, lastName, emailAddress) 
+	VALUES ("Big Tony", "Constanza", "big.tony.constanza@test.test");
+SET @clientId = LAST_INSERT_ID();
 
 SET @appointmentTime = DATE_ADD(NOW(), INTERVAL 3 HOUR);
 
-INSERT INTO Appointment (scheduledTime, locationId)
-	VALUES (@appointmentTime, 1);
+INSERT INTO Appointment (scheduledTime, clientId, locationId)
+	VALUES (@appointmentTime, @clientId, 1);
         
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("Tony",
-    (SELECT appointmentId
-		FROM Appointment
-        WHERE scheduledTime=@appointmentTime AND locationId=1),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="first_name"));
-            
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("Constanza",
-    (SELECT appointmentId
-		FROM Appointment
-        WHERE scheduledTime=@appointmentTime AND locationId=1),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="last_name"));
+INSERT INTO Client (firstName, lastName, emailAddress)
+	VALUES ("Ralph", "Schmidt", "ralphman@test.test");
+SET @clientId = LAST_INSERT_ID();
+    
+INSERT INTO Appointment (scheduledTime, clientId, locationId) 
+	VALUES ("2017-05-28 16:30:00", @clientId, 1);
 
-INSERT INTO Appointment (scheduledTime, locationId) 
-	VALUES ("2017-05-28 16:30:00", 1);
+SET @pharmacistQuestionId = (SELECT questionId FROM Question WHERE tag="pharmacist");
+SET @gambleQuestionId = (SELECT questionId FROM Question WHERE tag="gamble");
+SET @militaryStatusQuestionId = (SELECT questionId FROM Question WHERE tag="military_status");
+SET @fluentEnglishQuestionId = (SELECT questionId FROM Question WHERE tag="fluent_english");
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Ralph",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES (
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@pharmacistQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-	(SELECT questionId 
-		FROM Question 
-		WHERE tag="first_name"));
+    @pharmacistQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("Schmidt",
-    (SELECT appointmentId
-		FROM Appointment
-        WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="last_name"));
-
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("ralphman@gmail.com",
-	(SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId = 1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="email"));
-
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("(753) 875-3165",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES(
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+		WHERE questionId=@gambleQuestionId AND string="Never"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="phone_number"));
+    @gambleQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES ("No",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES(
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@militaryStatusQuestionId AND string="None"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="pharmacist"));
+    @militaryStatusQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Occasionally",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES(
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@fluentEnglishQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="gamble"));
+    @fluentEnglishQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("None",
-	(SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="military_status"));
+INSERT INTO Client (firstName, lastName, emailAddress)
+	VALUES ("Kathy", "Stevens", "kstev89@test.test");
+SET @clientId = LAST_INSERT_ID();
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Yes",
-	(SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="fluent_english"));
+INSERT INTO Appointment (scheduledTime, clientId, locationId) 
+	VALUES ("2017-06-01 12:45", @clientId, 5);
 
-INSERT INTO Appointment (scheduledTime, locationId) 
-	VALUES ("2017-06-01 12:45", 5);
-	
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Kathy",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES(
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@pharmacistQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="first_name"));
-      
-INSERT INTO Answer (string, appointmentId, questionId)
-	VALUES("Stevens",
-    (SELECT appointmentId
-		FROM Appointment
-		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-	(SELECT questionId
-		FROM Question
-        WHERE tag="last_name"));
+    @pharmacistQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("kstev89@gmail.com",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES(
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@militaryStatusQuestionId AND string="Active Reserve"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="email"));
+    @militaryStatusQuestionId);
 
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Yes",
-	(SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="pharmacist"));
-
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES("Active Reserve",
-	(SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="military_status"));
-
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES ("No",
+INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+	VALUES (
+    (SELECT possibleAnswerId
+		FROM PossibleAnswer
+        WHERE questionId=@fluentEnglishQuestionId AND string="No"),
     (SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="fluent_english"));
-
-INSERT INTO Answer (string, appointmentId, questionId) 
-	VALUES ("Spanish",
-    (SELECT appointmentId 
-		FROM Appointment 
-		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    (SELECT questionId 
-		FROM Question 
-		WHERE tag="strongest_language"));
+    @fluentEnglishQuestionId);
 
 -- -- test queries -- --
 SELECT * FROM Question;
-SELECT * FROM QuestionInformation;
 SELECT * FROM PossibleAnswer;
 SELECT * FROM Location;
+SELECT * FROM Client;
 SELECT * FROM Appointment;
 SELECT * FROM Answer;
 
 -- all answers for an appointment
-SELECT Question.string AS question, Answer.string as answer 
+SELECT Question.string AS question, PossibleAnswer.string as answer 
 	FROM Answer
-	JOIN Question ON Answer.questionId = Question.questionId 
+	JOIN Question ON Answer.questionId = Question.questionId
+    JOIN PossibleAnswer ON Answer.possibleAnswerId = PossibleAnswer.possibleAnswerId
 	WHERE appointmentId = 1;
     
-SELECT Question.string AS question, Answer.string as answer 
+SELECT Question.string AS question, PossibleAnswer.string as answer 
 	FROM Answer 
-	JOIN Question ON Answer.questionId = Question.questionId 
-	WHERE appointmentId = 2;
+	JOIN Question ON Answer.questionId = Question.questionId
+    JOIN PossibleAnswer ON Answer.possibleAnswerId = PossibleAnswer.possibleAnswerId
+	WHERE appointmentId = 3;
 
 -- active questions
 SELECT questionId, string FROM Question WHERE archived=FALSE;

--- a/mysql scripts/test_data/appointmentDBTestData.sql
+++ b/mysql scripts/test_data/appointmentDBTestData.sql
@@ -1,95 +1,95 @@
 USE vita;
 
 -- sample questions with choices, if applicable
-INSERT INTO Question (string, orderIndex, tag)
+INSERT INTO LitmusQuestion (string, orderIndex, tag)
 	VALUES ("Are you a phamacist?", 1, "pharmacist");
     
-INSERT INTO Question (string, orderIndex, tag)
+INSERT INTO LitmusQuestion (string, orderIndex, tag)
 	VALUES ("How often do you gamble?", 2, "gamble");
     
-INSERT INTO Question (string, orderIndex, tag)
+INSERT INTO LitmusQuestion (string, orderIndex, tag)
 	VALUES ("Indicate your military status", 3, "military_status");
     
-INSERT INTO Question (string, orderIndex, tag)
+INSERT INTO LitmusQuestion (string, orderIndex, tag)
 	VALUES ("Can you speak fluent English?", 4, "fluent_english");
     
 -- Sample Possible Answer data
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Yes", 1,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="pharmacist"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("No", 2,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="pharmacist"));
 	
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Frequently", 1,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Occasionally", 2,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Rarely", 3,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="gamble"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Never", 4,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="gamble"));
 	
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Active Duty", 1,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Active Reserve", 2,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Disabled Veterans", 3,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Inactive Reserve", 4,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="military_status"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("None", 5,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="military_status"));
 	
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("Yes", 1,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="fluent_english"));
 		
-INSERT INTO PossibleAnswer (string, orderIndex, questionId) 
+INSERT INTO PossibleAnswer (string, orderIndex, litmusQuestionId) 
 	VALUES ("No", 2,
-	(SELECT questionId 
-		FROM Question 
+	(SELECT litmusQuestionId 
+		FROM LitmusQuestion 
 		WHERE tag="fluent_english"));
 
 -- sample locations
@@ -139,50 +139,50 @@ SET @clientId = LAST_INSERT_ID();
 INSERT INTO Appointment (scheduledTime, clientId, locationId) 
 	VALUES ("2017-05-28 16:30:00", @clientId, 1);
 
-SET @pharmacistQuestionId = (SELECT questionId FROM Question WHERE tag="pharmacist");
-SET @gambleQuestionId = (SELECT questionId FROM Question WHERE tag="gamble");
-SET @militaryStatusQuestionId = (SELECT questionId FROM Question WHERE tag="military_status");
-SET @fluentEnglishQuestionId = (SELECT questionId FROM Question WHERE tag="fluent_english");
+SET @pharmacistLitmusQuestionId = (SELECT litmusQuestionId FROM LitmusQuestion WHERE tag="pharmacist");
+SET @gambleLitmusQuestionId = (SELECT litmusQuestionId FROM LitmusQuestion WHERE tag="gamble");
+SET @militaryStatusLitmusQuestionId = (SELECT litmusQuestionId FROM LitmusQuestion WHERE tag="military_status");
+SET @fluentEnglishLitmusQuestionId = (SELECT litmusQuestionId FROM LitmusQuestion WHERE tag="fluent_english");
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES (
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@pharmacistQuestionId AND string="Yes"),
+        WHERE litmusQuestionId=@pharmacistLitmusQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    @pharmacistQuestionId);
+    @pharmacistLitmusQuestionId);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES(
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-		WHERE questionId=@gambleQuestionId AND string="Never"),
+		WHERE litmusQuestionId=@gambleLitmusQuestionId AND string="Never"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    @gambleQuestionId);
+    @gambleLitmusQuestionId);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES(
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@militaryStatusQuestionId AND string="None"),
+        WHERE litmusQuestionId=@militaryStatusLitmusQuestionId AND string="None"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    @militaryStatusQuestionId);
+    @militaryStatusLitmusQuestionId);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES(
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@fluentEnglishQuestionId AND string="Yes"),
+        WHERE litmusQuestionId=@fluentEnglishLitmusQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-05-28 16:30:00" AND locationId=1),
-    @fluentEnglishQuestionId);
+    @fluentEnglishLitmusQuestionId);
 
 INSERT INTO Client (firstName, lastName, emailAddress)
 	VALUES ("Kathy", "Stevens", "kstev89@test.test");
@@ -191,38 +191,38 @@ SET @clientId = LAST_INSERT_ID();
 INSERT INTO Appointment (scheduledTime, clientId, locationId) 
 	VALUES ("2017-06-01 12:45", @clientId, 5);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES(
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@pharmacistQuestionId AND string="Yes"),
+        WHERE litmusQuestionId=@pharmacistLitmusQuestionId AND string="Yes"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    @pharmacistQuestionId);
+    @pharmacistLitmusQuestionId);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES(
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@militaryStatusQuestionId AND string="Active Reserve"),
+        WHERE litmusQuestionId=@militaryStatusLitmusQuestionId AND string="Active Reserve"),
 	(SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    @militaryStatusQuestionId);
+    @militaryStatusLitmusQuestionId);
 
-INSERT INTO Answer (possibleAnswerId, appointmentId, questionId) 
+INSERT INTO Answer (possibleAnswerId, appointmentId, litmusQuestionId) 
 	VALUES (
     (SELECT possibleAnswerId
 		FROM PossibleAnswer
-        WHERE questionId=@fluentEnglishQuestionId AND string="No"),
+        WHERE litmusQuestionId=@fluentEnglishLitmusQuestionId AND string="No"),
     (SELECT appointmentId 
 		FROM Appointment 
 		WHERE scheduledTime="2017-06-01 12:45" AND locationId=5),
-    @fluentEnglishQuestionId);
+    @fluentEnglishLitmusQuestionId);
 
 -- -- test queries -- --
-SELECT * FROM Question;
+SELECT * FROM LitmusQuestion;
 SELECT * FROM PossibleAnswer;
 SELECT * FROM Location;
 SELECT * FROM Client;
@@ -230,20 +230,20 @@ SELECT * FROM Appointment;
 SELECT * FROM Answer;
 
 -- all answers for an appointment
-SELECT Question.string AS question, PossibleAnswer.string as answer 
+SELECT LitmusQuestion.string AS question, PossibleAnswer.string as answer 
 	FROM Answer
-	JOIN Question ON Answer.questionId = Question.questionId
+	JOIN LitmusQuestion ON Answer.litmusQuestionId = LitmusQuestion.litmusQuestionId
     JOIN PossibleAnswer ON Answer.possibleAnswerId = PossibleAnswer.possibleAnswerId
 	WHERE appointmentId = 1;
     
-SELECT Question.string AS question, PossibleAnswer.string as answer 
+SELECT LitmusQuestion.string AS question, PossibleAnswer.string as answer 
 	FROM Answer 
-	JOIN Question ON Answer.questionId = Question.questionId
+	JOIN LitmusQuestion ON Answer.litmusQuestionId = LitmusQuestion.litmusQuestionId
     JOIN PossibleAnswer ON Answer.possibleAnswerId = PossibleAnswer.possibleAnswerId
 	WHERE appointmentId = 3;
 
 -- active questions
-SELECT questionId, string FROM Question WHERE archived=FALSE;
+SELECT litmusQuestionId, string FROM LitmusQuestion WHERE archived=FALSE;
 
 -- required questions
-SELECT questionId, string FROM Question WHERE required=TRUE;
+SELECT litmusQuestionId, string FROM LitmusQuestion WHERE required=TRUE;

--- a/server/queue.php
+++ b/server/queue.php
@@ -3,8 +3,9 @@
 	$conn = $DB_CONN;
 
 	// TODO make this handle multiple locations, if necessary
-	$stmt = $conn->prepare('SELECT DISTINCT appointmentId, scheduledTime
+	$stmt = $conn->prepare('SELECT DISTINCT appointmentId, scheduledTime, firstName, lastName
 		FROM Appointment
+		JOIN Client ON Appointment.clientId = Client.clientId
 		WHERE (Appointment.scheduledTime >= NOW() AND Appointment.scheduledTime < DATE_ADD(CURDATE(), INTERVAL 1 DAY))
 			AND Appointment.archived = FALSE
 		ORDER BY Appointment.scheduledTime ASC');
@@ -12,34 +13,15 @@
 	$stmt->execute();
 	$results = $stmt->fetchAll();
 
-	$firstNameStmt = $conn->prepare('SELECT Answer.string AS firstName
-		FROM Answer
-		JOIN Question ON Answer.questionId = Question.questionId
-		WHERE Question.tag = "first_name" AND Answer.appointmentId = ?');
-
-	$lastNameStmt = $conn->prepare('SELECT Answer.string AS lastName
-		FROM Answer
-		JOIN Question ON Answer.questionId = Question.questionId
-		WHERE Question.tag = "last_name" AND Answer.appointmentId = ?');
-
 	// We must only display the first letter of the last name
 	// We do this server-side since we can't disclose the data client-side
 	$appointments = [];
 	foreach ($results as $result) {
-		$firstNameStmt->execute(array($result['appointmentId']));
-		$lastNameStmt->execute(array($result['appointmentId']));
-
-		$firstNameResult = $firstNameStmt->fetch();
-		$lastNameResult = $lastNameStmt->fetch();
-
-		$result['firstName'] = $firstNameResult['firstName'];
-		$result['lastName'] = substr($lastNameResult['lastName'], 0, 1);
+		$result['lastName'] = substr($result['lastName'], 0, 1);
 
 		$appointments[] = $result;
 	}
 
 	echo json_encode($appointments);
 
-	$firstNameStmt = null;
-	$lastNameStmt = null;
 	$stmt = null;


### PR DESCRIPTION
Redid the questions DB after the talk with Austin. Basically, the Questions table was only meant to store the litmus test questions, not stuff like "What is your first name", "What is your last name", etc. This means that the litmus test questions are all select inputs. So the database has been redesigned to support that instead of what we were doing before.
- Renamed Question table to LitmusQuestion in order to avoid any confusion in the future about what type of questions this table is supposed to hold.
- Created a Client table which stores a client's firstName, lastName, emailAddress, and a nullable languages section which would store the languages they know if they're not fluent in English
- Both LitmusQuestion and PossibleAnswer now have a "orderIndex" field which specifies the ordering in which they should appear on the form and in the select input, respectively. A simple ORDER BY orderIndex ASC will get those in the proper order.
- Left PossibleAnswer table which stores possible answers for a question (the options in a select input)
- Left LitmusQuestion table which stores the questions
- Answer table now references an Appointment, a LitmusQuestion, and a PossibleAnswer. From that you can determine what the answers were for any appointment.
- Fixed Queue after this change
- Fixed test data

Here is the current, working ERD:

![appointmentdberd](https://cloud.githubusercontent.com/assets/9295744/26181711/e488b2ca-3b37-11e7-9077-c240c4e31283.png)
