### PR TITLE
Privilege Checking Helper

### DIFF
--- a/server/user.class.php
+++ b/server/user.class.php
@@ -3,18 +3,13 @@ require_once 'login.class.php';
 require_once 'callbacks.php';
 require_once 'config.php';
 
-// META - Can give users permissions(inclusive?!)
 define('PrivilegeControl', 'PrivilegeControl');
-
-// Can Unassign users from a shift
 define('UserShiftControl', 'UserShiftControl');
-
-// Can Modify Appointments
 define('AppointmentControl', 'AppointmentControl');
 
 
 /**
-* Class for easily checking user permissions
+* Class for easily checking user privileges
 * Simply instantiate and use
 */
 
@@ -51,11 +46,11 @@ class User
 	}
 
 	/**
-	* Checks whether the user has specifed permission
+	* Checks whether the user has specifed privilege
 	* 
 	* @return boolean
 	*/ 
-	public function hasPermission($permissionTag){
+	public function hasPrivilege($privilegeTag){
 		GLOBAL $DB_CONN;
 
 		$userId = $this->getUserId();
@@ -69,7 +64,7 @@ class User
 
 
 		$stmt = $DB_CONN->prepare($query);
-		$stmt->execute(array($userId,$permissionTag));
+		$stmt->execute(array($userId,$privilegeTag));
 
 		$results = $stmt->fetchAll();
 

--- a/server/user.class.php
+++ b/server/user.class.php
@@ -57,7 +57,7 @@ class User
 
 		$query = "SELECT userId 
 			FROM userPrivilege
-				INNER JOIN privilege ON privilege.privilegeId = userprivilege.userPrivilegeId
+				INNER JOIN privilege ON privilege.privilegeId = userPrivilege.userPrivilegeId
 			WHERE 1=1
 				AND userId = ?
 				AND tag LIKE ?";
@@ -68,10 +68,6 @@ class User
 
 		$results = $stmt->fetchAll();
 
-		if(empty($results)){
-			return false;
-		}else{
-			return true;
-		}
+		return !empty($results);
 	}
 }

--- a/server/user.class.php
+++ b/server/user.class.php
@@ -1,0 +1,82 @@
+<?
+require_once 'login.class.php';
+require_once 'callbacks.php';
+require_once 'config.php';
+
+// META - Can give users permissions(inclusive?!)
+define('PrivilegeControl', 'PrivilegeControl');
+
+// Can Unassign users from a shift
+define('UserShiftControl', 'UserShiftControl');
+
+// Can Modify Appointments
+define('AppointmentControl', 'AppointmentControl');
+
+
+/**
+* Class for easily checking user permissions
+* Simply instantiate and use
+*/
+
+class User
+{
+
+	/**
+	* Returns user id, will return FALSE if not logged in!
+	* 
+	* @return int
+	*/ 
+	public function getUserId(){
+		$LOGIN = getLoginClass();
+
+		## Check Login Status
+		if(!$LOGIN->checkLogin()){
+			$LOGIN->logout();
+			return false;
+		}
+
+		return $_SESSION['USER__ID'];
+	}
+
+
+	/**
+	* Checks whether the user is still lagged in
+	* 
+	* @return boolean
+	*/ 
+	public function isLoggedIn(){
+		$LOGIN = getLoginClass();
+
+		return $LOGIN->checkLogin();
+	}
+
+	/**
+	* Checks whether the user has specifed permission
+	* 
+	* @return boolean
+	*/ 
+	public function hasPermission($permissionTag){
+		GLOBAL $DB_CONN;
+
+		$userId = $this->getUserId();
+
+		$query = "SELECT userId 
+			FROM userPrivilege
+				INNER JOIN privilege ON privilege.privilegeId = userprivilege.userPrivilegeId
+			WHERE 1=1
+				AND userId = ?
+				AND tag = ?";
+
+
+		$stmt = $DB_CONN->prepare($query);
+		$stmt->execute(array($userId,$permissionTag));
+
+		$results = $stmt->fetchAll();
+
+		if(empty($results)){
+			return false;
+		}else{
+			return true;
+		}
+	}
+}

--- a/server/user.class.php
+++ b/server/user.class.php
@@ -60,7 +60,7 @@ class User
 				INNER JOIN privilege ON privilege.privilegeId = userprivilege.userPrivilegeId
 			WHERE 1=1
 				AND userId = ?
-				AND tag = ?";
+				AND tag LIKE ?";
 
 
 		$stmt = $DB_CONN->prepare($query);


### PR DESCRIPTION
Small helper class to make checking privileges easier. To test, you'll have to login which requires a user with associated login row. You'll to manually enter these if you don't have a local SMTP setup to register via email. 

Notes
1. Please note that privilege tags are defined constants, feel free to debate this. Should make it harder to mistype privileges. 
2. As Matt suggested, tags are used, not ids.
3. getUserId has a potentially unwanted side effect, will logout users past the threshold