### PR TITLE
Conditionals for Appoinment Signup

### DIFF
--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -111,7 +111,7 @@ function storeAppointment($data){
 		$DB_CONN->rollback();
 
 		// TODO
-		// mail('someoneimportant@important.com', 'Please help, everything is on fire?', print_r($e, true).print_r($data, true));
+		// mail('vita@cse.unl.edu', 'Please help, everything is on fire?', print_r($e, true).print_r($data, true));
 	}
 
 	## Return

--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -105,13 +105,13 @@ function storeAppointment($data){
 
 		// if email is set and passes simple validation (x@x)
 		if($data['email'] && preg_match('/.+@.+/', $data['email'])){
-			mail($data['email'], 'Lincoln VITA - Appointment', $response['message']);
+			// mail($data['email'], 'Lincoln VITA - Appointment', $response['message']);
 		}
 	} catch (Exception $e) {
 		$DB_CONN->rollback();
 
 		// TODO
-		mail('someoneimportant@important.com', 'Please help, everything is on fire?', print_r($e, true).print_r($data, true));
+		// mail('someoneimportant@important.com', 'Please help, everything is on fire?', print_r($e, true).print_r($data, true));
 	}
 
 	## Return

--- a/signup/index.php
+++ b/signup/index.php
@@ -43,6 +43,24 @@
 						<label class="form-label form-required" for="phone">Phone Number</label>
 					</div>
 
+					<div class="form-radio row" id="student">
+						<label for="student" class="col">Are you a UNL student?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="yes">
+								<input type="radio" id="yes" value="yes" name="student">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="no">
+								<input type="radio" id="no" value="no" name="student">No
+							</label>
+						</div>
+					</div>
+
+					<div class="form-textfield" id="studentId" style="display: none;">
+						<input type="text" name="studentnuid" id="studentnuid" required>
+						<span class="form-bar"></span>
+						<label class="form-label form-required" for="studentnuid">What is your NUID?</label>
+					</div>
+
 					<h3 class="form-subheading">Appointment Information</h3>
 
 					<?php

--- a/signup/index.php
+++ b/signup/index.php
@@ -15,7 +15,7 @@
 	<div class="container">
 		<div class="row justify-content-center">
 			<div class="col col-12 col-sm-8">
-				<div id="responsePlaceholder" style="display: none;"></div>
+				<div id="responsePlaceholder" class="mt-5" style="display: none;"></div>
 				<form class="cmxform" id="vitaSignupForm" method="post" action="" autocomplete="off">
 					<h2 class="form-title">Sign Up for a VITA Appointment</h2>
 

--- a/signup/index.php
+++ b/signup/index.php
@@ -43,32 +43,286 @@
 						<label class="form-label form-required" for="phone">Phone Number</label>
 					</div>
 
-					<div class="form-radio row" id="student">
-						<label for="student" class="col">Are you a UNL student?</label>
+					<h3 class="form-subheading">Appointment Information</h3>
+
+					<div class="form-radio row">
+						<label for="depreciation_schedule" class="col form-required">Will you require a Depreciation Schedule?</label>
 						<div class="col btn-group" data-toggle="buttons">
-							<label class="btn btn-outline-secondary" for="yes">
-								<input type="radio" id="yes" value="yes" name="student">Yes
+							<label class="btn btn-outline-secondary" for="1yes">
+								<input type="radio" id="1yes" value="1" class="required" name="1">Yes
 							</label>
-							<label class="btn btn-outline-secondary" for="no">
-								<input type="radio" id="no" value="no" name="student">No
+							<label class="btn btn-outline-secondary" for="1no">
+								<input type="radio" id="1no" value="2" class="required" name="1">No
+							</label>
+							<label class="btn btn-outline-secondary" for="1unsure">
+								<input type="radio" id="1unsure" value="3" class="required" name="1">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="schedule_f" class="col form-required">Will you require a Schedule F (Farm)?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="2yes">
+								<input type="radio" id="2yes" value="1" class="required" name="2">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="2no">
+								<input type="radio" id="2no" value="2" class="required" name="2">No
+							</label>
+							<label class="btn btn-outline-secondary" for="2unsure">
+								<input type="radio" id="2unsure" value="3" class="required" name="2">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row" id="homeBased">
+						<label for="self_employed" class="col form-required">Are you self-employed or own a home-based business?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="3yes">
+								<input type="radio" id="3yes" value="1" class="required" name="3">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="3no">
+								<input type="radio" id="3no" value="2" class="required" name="3">No
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row" id="homeBasedNetLoss" style="display: none;">
+						<label for="net_loss" class="col form-required">Does your home-based business or self-employment have a net loss?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="4yes">
+								<input type="radio" id="4yes" value="1" class="required" name="4">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="4no">
+								<input type="radio" id="4no" value="2" class="required" name="4">No
+							</label>
+							<label class="btn btn-outline-secondary" for="4unsure">
+								<input type="radio" id="4unsure" value="3" class="required" name="4">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row" id="homeBased10000" style="display: none;">
+						<label for="more_than_10000_expenses" class="col form-required">Does your home-based business or self-employment have more than $10,000 in expenses?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="5yes">
+								<input type="radio" id="5yes" value="1" class="required" name="5">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="5no">
+								<input type="radio" id="5no" value="2" class="required" name="5">No
+							</label>
+							<label class="btn btn-outline-secondary" for="5unsure">
+								<input type="radio" id="5unsure" value="3" class="required" name="5">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row" id="homeBasedSEP" style="display: none;">
+						<label for="retirement_plans" class="col form-required">Does your home-based business or self-employment have self-employed, SEP, SIMPLE, or qualified retirement plans?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="6yes">
+								<input type="radio" id="6yes" value="1" class="required" name="6">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="6no">
+								<input type="radio" id="6no" value="2" class="required" name="6">No
+							</label>
+							<label class="btn btn-outline-secondary" for="6unsure">
+								<input type="radio" id="6unsure" value="3" class="required" name="6">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row" id="homeBasedEmployees" style="display: none;">
+						<label for="any_employees" class="col form-required">Does your home-based business or self-employment have employees?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="7yes">
+								<input type="radio" id="7yes" value="1" class="required" name="7">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="7no">
+								<input type="radio" id="7no" value="2" class="required" name="7">No
+							</label>
+							<label class="btn btn-outline-secondary" for="7unsure">
+								<input type="radio" id="7unsure" value="3" class="required" name="7">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="casualty_losses" class="col form-required">Will your return have casualty losses?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="8yes">
+								<input type="radio" id="8yes" value="1" class="required" name="8">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="8no">
+								<input type="radio" id="8no" value="2" class="required" name="8">No
+							</label>
+							<label class="btn btn-outline-secondary" for="8unsure">
+								<input type="radio" id="8unsure" value="3" class="required" name="8">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="theft_losses" class="col form-required">Will your return have theft losses?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="9yes">
+								<input type="radio" id="9yes" value="1" class="required" name="9">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="9no">
+								<input type="radio" id="9no" value="2" class="required" name="9">No
+							</label>
+							<label class="btn btn-outline-secondary" for="9unsure">
+								<input type="radio" id="9unsure" value="3" class="required" name="9">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="schedule_e" class="col form-required">Will you require a Schedule E (rental income)?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="10yes">
+								<input type="radio" id="10yes" value="1" class="required" name="10">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="10no">
+								<input type="radio" id="10no" value="2" class="required" name="10">No
+							</label>
+							<label class="btn btn-outline-secondary" for="10unsure">
+								<input type="radio" id="10unsure" value="3" class="required" name="10">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="schedule_k-1" class="col form-required">Will you require a Schedule K-1 (partnership or trust income)?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="11yes">
+								<input type="radio" id="11yes" value="1" class="required" name="11">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="11no">
+								<input type="radio" id="11no" value="2" class="required" name="11">No
+							</label>
+							<label class="btn btn-outline-secondary" for="11unsure">
+								<input type="radio" id="11unsure" value="3" class="required" name="11">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="dividends_income" class="col form-required">Do you have income from dividends, capital gains, or minimal brokerage transactions?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="12yes">
+								<input type="radio" id="12yes" value="1" class="required" name="12">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="12no">
+								<input type="radio" id="12no" value="2" class="required" name="12">No
+							</label>
+							<label class="btn btn-outline-secondary" for="12unsure">
+								<input type="radio" id="12unsure" value="3" class="required" name="12">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="current_bankruptcy" class="col form-required">Will your return involve a current bankruptcy?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="13yes">
+								<input type="radio" id="13yes" value="1" class="required" name="13">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="13no">
+								<input type="radio" id="13no" value="2" class="required" name="13">No
+							</label>
+							<label class="btn btn-outline-secondary" for="13unsure">
+								<input type="radio" id="13unsure" value="3" class="required" name="13">Unsure
+							</label>
+						</div>
+					</div>
+					<div class="form-radio row">
+						<label for="multiple_states" class="col form-required">Will your return involve income from more than one state?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="14yes">
+								<input type="radio" id="14yes" value="1" class="required" name="14">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="14no">
+								<input type="radio" id="14no" value="2" class="required" name="14">No
+							</label>
+							<label class="btn btn-outline-secondary" for="14unsure">
+								<input type="radio" id="14unsure" value="3" class="required" name="14">Unsure
 							</label>
 						</div>
 					</div>
 
-					<div class="form-textfield" id="studentId" style="display: none;">
-						<input type="text" name="studentnuid" id="studentnuid" required>
-						<span class="form-bar"></span>
-						<label class="form-label form-required" for="studentnuid">What is your NUID?</label>
+					<div class="form-radio row" id="studentUNL">
+						<label for="15" class="col form-required">Are you a University of Nebraska-Lincoln student?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="studentyes">
+								<input type="radio" id="studentyes" value="1" name="15">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="studentno">
+								<input type="radio" id="studentno" value="2" name="15">No
+							</label>
+						</div>
 					</div>
 
-					<h3 class="form-subheading">Appointment Information</h3>
+					<div class="form-radio row" id="studentInt" style="display: none;">
+						<label for="16" class="col">Are you an International Student Scholar?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="studentIntyes">
+								<input type="radio" id="studentIntyes" value="1" name="16">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="studentIntno">
+								<input type="radio" id="studentIntno" value="2" name="16">No
+							</label>
+						</div>
+					</div>
 
-					<?php
-						require_once "$root/server/signup.php";
-						getLitmusQuestions();
-					?>
+					<div class="form-radio row" id="studentIntVisa" style="display: none;">
+						<label for="17" class="col">What sort of visa are you on?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="f1">
+								<input type="radio" id="f1" value="4" name="17">F-1
+							</label>
+							<label class="btn btn-outline-secondary" for="j1">
+								<input type="radio" id="j1" value="5" name="17">J-1
+							</label>
+							<label class="btn btn-outline-secondary" for="h1b">
+								<input type="radio" id="h1b" value="6" name="17">H1B
+							</label>
+						</div>
+					</div>
 
-					<input type="submit" value="Submit" class="submit button vita-background-primary">
+					<div class="form-radio row" id="studentf1" style="display: none;">
+						<label for="18" class="col">How long have you been in the United States?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="2011">
+								<input type="radio" id="2011" value="7" name="18">2011 or earlier
+							</label>
+							<label class="btn btn-outline-secondary" for="2012">
+								<input type="radio" id="2012" value="8" name="18">2012 or later
+							</label>
+						</div>
+					</div>
+
+					<div class="form-radio row" id="studentj1" style="display: none;">
+						<label for="18" class="col">How long have you been in the United States?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="2014">
+								<input type="radio" id="2014" value="9" name="18">2014 or earlier
+							</label>
+							<label class="btn btn-outline-secondary" for="2015">
+								<input type="radio" id="2015" value="10" name="18">2015 or later
+							</label>
+						</div>
+					</div>
+
+					<div class="form-radio row" id="studenth1b" style="display: none;">
+						<label for="19" class="col">Have you been on this visa for less than 183 days and in the United States for less than 5 years?</label>
+						<div class="col btn-group" data-toggle="buttons">
+							<label class="btn btn-outline-secondary" for="studenth1byes">
+								<input type="radio" id="studenth1byes" value="1" name="19">Yes
+							</label>
+							<label class="btn btn-outline-secondary" for="studenth1bno">
+								<input type="radio" id="studenth1bno" value="2" name="19">No
+							</label>
+						</div>
+					</div>
+
+					<div id="appointmentPicker">
+						Appointment Picker
+					</div>
+
+					<div id="studentScholarAppointmentPicker" style="display: none;">
+						Student Scholar Appointment Picker
+					</div>
+
+					<input type="submit" value="Submit" class="submit btn btn-primary mb-5 vita-background-primary">
 				</form>
 			</div>
 		</div>

--- a/signup/index.php
+++ b/signup/index.php
@@ -16,7 +16,7 @@
 		<div class="row justify-content-center">
 			<div class="col col-12 col-sm-8">
 				<div id="responsePlaceholder" class="mt-5" style="display: none;"></div>
-				<form class="cmxform" id="vitaSignupForm" method="post" action="" autocomplete="off">
+				<form class="cmxform mb-5" id="vitaSignupForm" method="post" action="" autocomplete="off">
 					<h2 class="pt-5">Sign Up for a VITA Appointment</h2>
 
 					<div class="form-textfield">
@@ -314,11 +314,11 @@
 						</div>
 					</div>
 
-					<div id="appointmentPicker">
+					<div id="appointmentPicker" style="height:300px">
 						Appointment Picker
 					</div>
 
-					<div id="studentScholarAppointmentPicker" style="display: none;">
+					<div id="studentScholarAppointmentPicker" style="display:none; height:300px">
 						Student Scholar Appointment Picker
 					</div>
 

--- a/signup/index.php
+++ b/signup/index.php
@@ -17,7 +17,7 @@
 			<div class="col col-12 col-sm-8">
 				<div id="responsePlaceholder" class="mt-5" style="display: none;"></div>
 				<form class="cmxform" id="vitaSignupForm" method="post" action="" autocomplete="off">
-					<h2 class="form-title">Sign Up for a VITA Appointment</h2>
+					<h2 class="pt-5">Sign Up for a VITA Appointment</h2>
 
 					<div class="form-textfield">
 						<input type="text" name="firstName" id="firstName">

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -37,18 +37,132 @@ function validateSignupForm() {
 }
 
 function conditionalFormFields() {
-	// Independent fields = #student
-	var student = $("#student").find('input:radio[name="student"]');
-	// Dependent fields = #studentId
-	var studentId = $("#studentId");
-	var all = studentId;
-	// Hide everything and selectively show content
-	student.change(function(){
+	// All of the questions that required conditions to be viewed.
+	var homeBased = $("#homeBased");
+	var homeBasedNetLoss = $("#homeBasedNetLoss");
+	var homeBased10000 = $("#homeBased10000");
+	var homeBasedSEP = $("#homeBasedSEP");
+	var homeBasedEmployees = $("#homeBasedEmployees");
+	var studentUNL = $("#studentUNL");
+	var studentInt = $("#studentInt");
+	var studentIntVisa = $("#studentIntVisa");
+	var studentf1 = $("#studentf1");
+	var studentj1 = $("#studentj1");
+	var studenth1b = $("#studenth1b");
+	var appointmentPicker = $("#appointmentPicker");
+	var studentScholarAppointmentPicker = $("#studentScholarAppointmentPicker");
+
+	// All the radio buttons
+	var homeBasedValues = homeBased.find('input:radio[name="3"]');
+	var studentUNLValues = studentUNL.find('input:radio[name="15"]');
+	var studentIntValues = studentInt.find('input:radio[name="16"]');
+	var studentIntVisaValues = studentIntVisa.find('input:radio[name="17"]');
+	var studentf1Values = studentf1.find('input:radio[name="18"]');
+	var studentj1Values = studentj1.find('input:radio[name="18"]');
+	var studenth1bValues = studenth1b.find('input:radio[name="18"]');
+
+	// To help hide everything and selectively show content
+	var allUnderHomeBasedValues = homeBasedNetLoss.add(homeBased10000).add(homeBasedSEP).add(homeBasedEmployees);
+	var allUnderstudentIntVisaValues = studentf1.add(studentj1).add(studenth1b);
+	var allUnderStudentIntValues = studentIntVisa.add(allUnderstudentIntVisaValues)
+	var allUnderStudentUNLValues = studentInt.add(allUnderStudentIntValues).add(allUnderstudentIntVisaValues);
+
+	// Independent field = #homeBased
+	// Dependent field = if yes --> #homeBasedNetLoss,#homeBased10000,#homeBasedSEP,#homeBasedEmployees
+	homeBasedValues.change(function() {
 		var value = this.value;
-		all.hide();
-		if(value === "yes"){
-			studentId.show();
+		if(this.checked){
+			if(value === "1"){
+				allUnderHomeBasedValues.slideUp(300);
+				allUnderHomeBasedValues.slideDown(300);
+			} else if(value === "2"){
+				allUnderHomeBasedValues.slideUp(300);
+			}
 		}
+	});
+
+	// Independent field = #studentUNL
+	// Dependent field = if yes --> #studentInt
+	//                   if no --> appointmentPicker
+	studentUNLValues.change(function(){
+		var value = this.value;
+		allUnderStudentUNLValues.slideUp(300);
+		if(value === "1"){
+			studentInt.slideDown(300);
+			studentIntValues.change();
+		} else if(value === "2"){
+			// TODO
+		}
+	});
+
+	// Independent field = #studentInt
+	// Dependent field = if yes --> #studentIntVisa
+	//                   if no --> appointmentPicker
+	studentIntValues.change(function() {
+		var value = this.value;
+		if(this.checked){
+			if(value === "1"){
+				allUnderStudentIntValues.slideUp(300);
+				studentIntVisa.slideDown(300);
+				studentIntVisaValues.change();
+			} else if(value === "2"){
+				allUnderStudentIntValues.slideUp(300);
+				// TODO
+			}
+		}
+	});
+
+	// Independent field = #studentIntVisa
+	// Dependent field = if f1 --> #studentf1
+	//                   if ja --> #studentja
+	//                   if h1b --> #studenth1b
+	studentIntVisaValues.change(function() {
+		var value = this.value;
+		if(this.checked){
+			if(value === "4"){
+				allUnderstudentIntVisaValues.slideUp(300);
+				studentf1.slideDown(300);
+				studentf1Values.change();
+			} else if(value === "5"){
+				allUnderstudentIntVisaValues.slideUp(300);
+				studentj1.slideDown(300);
+				studentj1Values.change();
+			} else if(value === "6"){
+				allUnderstudentIntVisaValues.slideUp(300);
+				studenth1b.slideDown(300);
+				studenth1bValues.change();
+			}
+		}
+	});
+
+	// Independent field = #studentf1
+	// Dependent field = if 2011 or earlier --> studentScholarAppointmentPicker
+	//                   if 2012 or later --> appointmentPicker
+	studentf1Values.change(function() {
+		var value = this.value;
+		if(this.checked){
+			if(value === "8"){
+				appointmentPicker.hide();
+				studentScholarAppointmentPicker.show();
+			} else {
+				studentScholarAppointmentPicker.hide();
+				appointmentPicker.show();
+			}
+		}
+	});
+
+	// Independent field = #studentj1
+	// Dependent field = any --> appointmentPicker
+	studentj1Values.change(function() {
+		studentScholarAppointmentPicker.hide();
+		appointmentPicker.show();
+	});
+
+	// Independent field = #studenth1b
+	// Dependent field = any --> appointmentPicker
+	studenth1bValues.change(function() {
+		studentScholarAppointmentPicker.hide();
+		appointmentPicker.show();
 	});
 
 }
@@ -81,7 +195,7 @@ $('#vitaSignupForm').submit(function(e) {
 
 		//TODO
 		"scheduledTime": '2017-07-26T15:30:00',
-		"siteId": 4
+		"siteId": 3
 	};
 
 	// AJAX Code To Submit Form.

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,4 +1,6 @@
 $(document).ready(function() {
+	conditionalFormFields();
+
 	validateSignupForm();
 
 	// Since non-required fields are "valid" when they are empty, we need an
@@ -32,6 +34,23 @@ function validateSignupForm() {
 			}
 		}
 	});
+}
+
+function conditionalFormFields() {
+	// Independent fields = #student
+	var student = $("#student").find('input:radio[name="student"]');
+	// Dependent fields = #studentId
+	var studentId = $("#studentId");
+	var all = studentId;
+	// Hide everything and selectively show content
+	student.change(function(){
+		var value = this.value;
+		all.hide();
+		if(value === "yes"){
+			studentId.show();
+		}
+	});
+
 }
 
 // Form submission

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -36,7 +36,35 @@ function validateSignupForm() {
 	});
 }
 
+function scrollDown(height, animationTime = 0) {
+	$('html, body').animate({
+		scrollTop: '+=' + height
+	}, animationTime);
+}
+
+function scrollToElement(element, animationTime = 0) {
+	$('.navbar-collapse.collapse').collapse('hide');
+	var offset = element.offset().top;
+	$('html, body').animate({
+		scrollTop: offset - $('.navbar').height() - 50
+	}, animationTime);
+}
+
+function showAppointmentPicker(animationTime = 300) {
+	$("#studentScholarAppointmentPicker").hide();
+	$("#appointmentPicker").show();
+	scrollToElement($("#appointmentPicker"), animationTime);
+}
+
+function showStudentScholarAppointmentPicker(animationTime = 300) {
+	$("#appointmentPicker").hide();
+	$("#studentScholarAppointmentPicker").show();
+	scrollToElement($("#studentScholarAppointmentPicker"), animationTime);
+}
+
 function conditionalFormFields() {
+	let animationTime = 300;
+
 	// All of the questions that required conditions to be viewed.
 	var homeBased = $("#homeBased");
 	var homeBasedNetLoss = $("#homeBasedNetLoss");
@@ -59,7 +87,7 @@ function conditionalFormFields() {
 	var studentIntVisaValues = studentIntVisa.find('input:radio[name="17"]');
 	var studentf1Values = studentf1.find('input:radio[name="18"]');
 	var studentj1Values = studentj1.find('input:radio[name="18"]');
-	var studenth1bValues = studenth1b.find('input:radio[name="18"]');
+	var studenth1bValues = studenth1b.find('input:radio[name="19"]');
 
 	// To help hide everything and selectively show content
 	var allUnderHomeBasedValues = homeBasedNetLoss.add(homeBased10000).add(homeBasedSEP).add(homeBasedEmployees);
@@ -73,10 +101,11 @@ function conditionalFormFields() {
 		var value = this.value;
 		if(this.checked){
 			if(value === "1"){
-				allUnderHomeBasedValues.slideUp(300);
-				allUnderHomeBasedValues.slideDown(300);
+				allUnderHomeBasedValues.slideUp(animationTime);
+				allUnderHomeBasedValues.slideDown(animationTime);
+				scrollDown(homeBased.height(), animationTime);
 			} else if(value === "2"){
-				allUnderHomeBasedValues.slideUp(300);
+				allUnderHomeBasedValues.slideUp(animationTime);
 			}
 		}
 	});
@@ -86,12 +115,13 @@ function conditionalFormFields() {
 	//                   if no --> appointmentPicker
 	studentUNLValues.change(function(){
 		var value = this.value;
-		allUnderStudentUNLValues.slideUp(300);
+		allUnderStudentUNLValues.slideUp(animationTime);
 		if(value === "1"){
-			studentInt.slideDown(300);
+			studentInt.slideDown(animationTime);
 			studentIntValues.change();
+			scrollDown(studentUNL.height(), animationTime);
 		} else if(value === "2"){
-			// TODO
+			showAppointmentPicker();
 		}
 	});
 
@@ -101,35 +131,35 @@ function conditionalFormFields() {
 	studentIntValues.change(function() {
 		var value = this.value;
 		if(this.checked){
+			allUnderStudentIntValues.slideUp(animationTime);
 			if(value === "1"){
-				allUnderStudentIntValues.slideUp(300);
-				studentIntVisa.slideDown(300);
+				studentIntVisa.slideDown(animationTime);
+				scrollDown(studentInt.height(), animationTime);
 				studentIntVisaValues.change();
 			} else if(value === "2"){
-				allUnderStudentIntValues.slideUp(300);
-				// TODO
+				showAppointmentPicker();
 			}
 		}
 	});
 
 	// Independent field = #studentIntVisa
 	// Dependent field = if f1 --> #studentf1
-	//                   if ja --> #studentja
+	//                   if j1 --> #studentj1
 	//                   if h1b --> #studenth1b
 	studentIntVisaValues.change(function() {
 		var value = this.value;
 		if(this.checked){
 			if(value === "4"){
-				allUnderstudentIntVisaValues.slideUp(300);
-				studentf1.slideDown(300);
+				allUnderstudentIntVisaValues.hide(animationTime);
+				studentf1.show(animationTime);
 				studentf1Values.change();
 			} else if(value === "5"){
-				allUnderstudentIntVisaValues.slideUp(300);
-				studentj1.slideDown(300);
+				allUnderstudentIntVisaValues.hide(animationTime);
+				studentj1.show(animationTime);
 				studentj1Values.change();
 			} else if(value === "6"){
-				allUnderstudentIntVisaValues.slideUp(300);
-				studenth1b.slideDown(300);
+				allUnderstudentIntVisaValues.hide(animationTime);
+				studenth1b.show(animationTime);
 				studenth1bValues.change();
 			}
 		}
@@ -142,11 +172,11 @@ function conditionalFormFields() {
 		var value = this.value;
 		if(this.checked){
 			if(value === "8"){
-				appointmentPicker.hide();
-				studentScholarAppointmentPicker.show();
+				scrollDown(appointmentPicker.height(), animationTime);
+				showStudentScholarAppointmentPicker(animationTime);
 			} else {
-				studentScholarAppointmentPicker.hide();
-				appointmentPicker.show();
+				scrollDown(studentScholarAppointmentPicker.height(), animationTime);
+				showAppointmentPicker(animationTime);
 			}
 		}
 	});
@@ -154,15 +184,13 @@ function conditionalFormFields() {
 	// Independent field = #studentj1
 	// Dependent field = any --> appointmentPicker
 	studentj1Values.change(function() {
-		studentScholarAppointmentPicker.hide();
-		appointmentPicker.show();
+		showAppointmentPicker(animationTime);
 	});
 
 	// Independent field = #studenth1b
 	// Dependent field = any --> appointmentPicker
 	studenth1bValues.change(function() {
-		studentScholarAppointmentPicker.hide();
-		appointmentPicker.show();
+		showAppointmentPicker(animationTime);
 	});
 
 }
@@ -180,10 +208,12 @@ $('#vitaSignupForm').submit(function(e) {
 	$('.form-radio').each(function(){
 		var checkedRadioBox = $(this).find('input[type="radio"]:checked');
 
-		questions.push({
-			id: checkedRadioBox.attr('name'),
-			value: checkedRadioBox.val()
-		});
+		if(checkedRadioBox.length>0) {
+			questions.push({
+				id: checkedRadioBox.attr('name'),
+				value: checkedRadioBox.val()
+			});
+		}
 	});
 
 	var data = {


### PR DESCRIPTION
All of the questions are now hard-coded in the signup form and conditionals have been implemented.

Testing considerations:
- [x] check the conditionals that have subconditionals. e.g. question A has options "yes" and "no", question B has options "yes" and "no", and question C has options "yes" and "no". Only question A is shown by default. When "yes" is selected for question A, question B appears. When "yes" is selected for question B, question C appears. Then if question is is switched to "no" (hiding questions B and C) and then switched back to "yes", "yes" should still be selected for question B, and question C should still be shown.

Additional things:
- [x] I noticed that all of the questions that either are not shown or are not selected (and not required) will still send a value with undefined for their id and value back to the server. These aren't put into the database, but I didn't know if it would be better to just add a simple check in the javascript before sending it to the server at all. i.e. `if(checkedRadioBox.length>0)` as the check on line 183 in `signup.js`.

Notes:
* I did put in containers for the appointment signup portion of the form. These will be changed with issue #75.
* in storeAppointment.php, I commented out the lines that would send the emails. These will be changed later, but currently, they break the code and make the front-end think think there was an error.