### PR TITLE
Redirect directories

### DIFF
--- a/scripts/CreateRedirectIndexPages.ps1
+++ b/scripts/CreateRedirectIndexPages.ps1
@@ -6,9 +6,10 @@ $path = '../'
 foreach ($directory in Get-ChildItem -recurse -dir $path) {
 	if (!(Test-Path ($directory.FullName + '\index.php'))) {
 		New-Item ($directory.FullName + '\index.php') -type file -value @"
-			"<?php 
-			$root = realpath($_SERVER["DOCUMENT_ROOT"]);
-			require_once "$root/server/redirect.php";
+<?php 
+$root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/redirect.php";
+?>
 "@
 	} 
 } 

--- a/scripts/CreateRedirectIndexPages.ps1
+++ b/scripts/CreateRedirectIndexPages.ps1
@@ -7,8 +7,8 @@ foreach ($directory in Get-ChildItem -recurse -dir $path) {
 	if (!(Test-Path ($directory.FullName + '\index.php'))) {
 		New-Item ($directory.FullName + '\index.php') -type file -value @"
 <?php 
-`$root = realpath(`$_SERVER["DOCUMENT_ROOT"]);
-require_once "`$root/server/redirect.php";
+	`$root = realpath(`$_SERVER["DOCUMENT_ROOT"]);
+	require_once "`$root/server/redirect.php";
 ?>
 "@
 	} 

--- a/scripts/CreateRedirectIndexPages.ps1
+++ b/scripts/CreateRedirectIndexPages.ps1
@@ -7,8 +7,8 @@ foreach ($directory in Get-ChildItem -recurse -dir $path) {
 	if (!(Test-Path ($directory.FullName + '\index.php'))) {
 		New-Item ($directory.FullName + '\index.php') -type file -value @"
 <?php 
-$root = realpath($_SERVER["DOCUMENT_ROOT"]);
-require_once "$root/server/redirect.php";
+`$root = realpath(`$_SERVER["DOCUMENT_ROOT"]);
+require_once "`$root/server/redirect.php";
 ?>
 "@
 	} 

--- a/scripts/CreateRedirectIndexPages.ps1
+++ b/scripts/CreateRedirectIndexPages.ps1
@@ -1,0 +1,14 @@
+# You may have to run the Unblock-File INSERT_RELATIVE_FILE_PATH_TO_THIS_FILE_HERE
+# If powershell is saying it won't run this due to a security risk
+
+# Recurse the entire code directory and create the index.php redirect file if necessary
+$path = '../'
+foreach ($directory in Get-ChildItem -recurse -dir $path) {
+	if (!(Test-Path ($directory.FullName + '\index.php'))) {
+		New-Item "$directory\index.php" -type file -value @"
+			"<?php 
+			$root = realpath($_SERVER["DOCUMENT_ROOT"]);
+			require_once "$root/server/redirect.php";
+"@
+	} 
+} 

--- a/scripts/CreateRedirectIndexPages.ps1
+++ b/scripts/CreateRedirectIndexPages.ps1
@@ -5,7 +5,7 @@
 $path = '../'
 foreach ($directory in Get-ChildItem -recurse -dir $path) {
 	if (!(Test-Path ($directory.FullName + '\index.php'))) {
-		New-Item "$directory\index.php" -type file -value @"
+		New-Item ($directory.FullName + '\index.php') -type file -value @"
 			"<?php 
 			$root = realpath($_SERVER["DOCUMENT_ROOT"]);
 			require_once "$root/server/redirect.php";

--- a/server/redirect.php
+++ b/server/redirect.php
@@ -1,0 +1,5 @@
+<!-- this file simply redirects back to the homepage. The point of this file is just so if we ever decide to redirect somewhere else, we need only change this file rather than every file that redirects -->
+<?php
+	header("Location: /");
+	die();
+?>


### PR DESCRIPTION
The idea here is that many directories of ours lack an `index.php`, so one can navigate to the file path in the URL and see the folder structure and files in there. And since we don't control (to my knowledge) the apache settings on the server, this is a workaround that will create an `index.php` in every directory that doesn't have one, and that `index.php` will simply redirect the user back to the homepage. For example, check out http://cse.unl.edu/~vita/server/

I pulled the redirect code out into `server/redirect.php` so if instead we ever want to redirect instead to unauthorized or something, we can do that. 

I think that this should be put into our build process so that it is never the case that we forget to do this. I did not commit the files that this powershell script creates, as it is unnecessary in my opinion, but if y'all disagree we can commit those 100+ files; but I think the build process route is the way to go.

**Testing**
*  You can test this by simply running the powershell file.
*  After you do, make sure the directories all have a `index.php` file
*  Navigate to a directory that should redirect now such as `/server/libs`
*  Ensure that you are redirected to the index page
*  Clean your git repo
    *  run a `git clean -df`
    *  run a `cd /server/libs/PHPExcel`
    *  run a `git clean -df` again
