### PR TITLE
Change from volunteer selection to station selection

### DIFF
--- a/mysql_scripts/table_creation/FullDB.sql
+++ b/mysql_scripts/table_creation/FullDB.sql
@@ -109,8 +109,7 @@ CREATE TABLE ServicedAppointment (
     timeAppointmentEnded DATETIME NULL DEFAULT NULL,
     completed BOOLEAN NULL DEFAULT NULL,
     notCompletedDescription VARCHAR(255) NULL DEFAULT NULL,
-	servicedBy INTEGER UNSIGNED NULL,
-	FOREIGN KEY(servicedBy) REFERENCES User(userId),
+	servicedByStation INTEGER UNSIGNED NULL,
 	appointmentId INTEGER UNSIGNED NOT NULL,
 	FOREIGN KEY(appointmentId) REFERENCES Appointment(appointmentId)
 );

--- a/mysql_scripts/test_data/FullDBTestData.sql
+++ b/mysql_scripts/test_data/FullDBTestData.sql
@@ -962,8 +962,8 @@ INSERT INTO Appointment (appointmentTimeId, clientId, language, ipAddress)
 
 -- serviced appointment
 SET @timeIn = DATE_ADD((SELECT scheduledTime FROM AppointmentTime WHERE appointmentTimeId = (SELECT appointmentTimeId FROM Appointment WHERE appointmentId = @appointment_appointment5Id)), INTERVAL 5 MINUTE);
-INSERT INTO ServicedAppointment (timeIn, servicedBy, appointmentId)
-	VALUES (@timeIn, @user_preparer1Id, @appointment_appointment5Id);
+INSERT INTO ServicedAppointment (timeIn, servicedByStation, appointmentId)
+	VALUES (@timeIn, 1, @appointment_appointment5Id);
 -- end serviced appointment
 
 

--- a/queue/private.php
+++ b/queue/private.php
@@ -91,8 +91,8 @@
 						</br>
 							<button type="button" class="btn" class="preparing" ng-disabled="!client.paperworkComplete" ng-class="client.preparing ? 'btn-primary': 'btn-secondary' " ng-click="nowPreparing()">Preparing</button>
 						</br>
-							<select ng-disabled="!client.preparing" ng-model="client.selectedVolunteer" ng-options="volunteer.name for volunteer in volunteers track by volunteer.userId">
-								<option value="" style="display:none;">-- Select Preparer --</option>
+							<select ng-disabled="!client.preparing" ng-model="client.selectedStationNumber" ng-options="stationNumber for stationNumber in stationNumbers">
+								<option value="" style="display:none;">-- Select Station --</option>
 							</select>
 						</br>
 							<button type="button" class="btn" class="ended" ng-disabled="!client.preparing" ng-class="client.ended ? 'btn-primary': 'btn-secondary' " ng-click="completeAppointment()">Finished</button>

--- a/queue/queue_private.js
+++ b/queue/queue_private.js
@@ -1,13 +1,6 @@
 queueApp.controller("QueuePrivateController", function($scope, $controller, QueueService) {
 	angular.extend(this, $controller('QueueController', {$scope: $scope}));
 
-	// We override the updateAppointmentInformation to update the volunteer select as well in the private queue on date changes
-	let parentUpdateAppointmentInformation = $scope.updateAppointmentInformation;
-	$scope.updateAppointmentInformation = function() {
-		parentUpdateAppointmentInformation();
-		$scope.getVolunteers();
-	}
-
 	function fixedEncodeURIComponent (str) {
   		return encodeURIComponent(str).replace(/[!'()]/g, escape).replace(/\*/g, "%2A");
 	}
@@ -32,13 +25,13 @@ queueApp.controller("QueuePrivateController", function($scope, $controller, Queu
 	};
 
 	$scope.completeAppointment = function() {
-		if ($scope.client.selectedVolunteer == null) {
-			alert('You must select who prepared the taxes');
+		if ($scope.client.selectedStationNumber == null) {
+			alert('You must select which station the taxes were prepared at');
 			return;
 		}
 
 		$scope.client.ended = true;
-		QueueService.finishAppointment(new Date().toISOString(), $scope.client.appointmentId, $scope.client.selectedVolunteer.userId);
+		QueueService.finishAppointment(new Date().toISOString(), $scope.client.appointmentId, $scope.client.selectedStationNumber);
 	};
 
 	$scope.incompleteAppointment = function(explanation) {
@@ -53,31 +46,7 @@ queueApp.controller("QueuePrivateController", function($scope, $controller, Queu
 		QueueService.cancelledAppointment($scope.client.appointmentId);
 	};
 
-	$scope.getVolunteers = function() {
-		let year = $scope.currentDate.getFullYear(),
-		month = $scope.currentDate.getMonth() + 1,
-		day = $scope.currentDate.getDate();
-		if (month < 10) month = "0" + month;
-
-		if ($scope.selectedSite == null || $scope.selectedSite.siteId == null) return;
-		let siteId = $scope.selectedSite.siteId;
-		
-		QueueService.getVolunteers(year + "-" + month + "-" + day, siteId).then(function(data) {
-			if(data == null) {
-				console.log('server error');
-			} else if(data.length > 0) {
-				$scope.volunteers = data.map((volunteer) => {
-					volunteer.name = `${volunteer.firstName} ${volunteer.lastName}`;
-					return volunteer;
-				});
-			} else {
-				$scope.volunteers = [];
-			}
-		});
-	}
-
-	// Invoke initially
-	$scope.getVolunteers();
+	$scope.stationNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25];
 });
 
 queueApp.filter('searchFor', function(){

--- a/queue/queue_service.js
+++ b/queue/queue_service.js
@@ -7,13 +7,6 @@ queueApp.factory("QueueService", function($http){
 				return null;
 			});
 		},
-		getVolunteers: function(date, siteId) {
-			return $http.get(`/server/queue/queue_priv.php?action=getVolunteers&date=${date}&siteId=${siteId}`).then(function(response){
-				return response.data;
-			},function(error){
-				return null;
-			});
-		},
 		getSites: function() {
 			return $http.get('/server/api/sites/getAll.php?siteId=true&title=true').then(function(response){
 				return response.data;
@@ -63,11 +56,11 @@ queueApp.factory("QueueService", function($http){
 				return null;
 			});
 		},
-		finishAppointment: function(time, id, servicedById) {
+		finishAppointment: function(time, id, stationNumber) {
 			return $http({
 				url: "/server/queue/queue_priv.php",
 				method: 'POST',
-				data: `action=appointmentComplete&time=${time}&id=${id}&servicedById=${servicedById}`,
+				data: `action=appointmentComplete&time=${time}&id=${id}&stationNumber=${stationNumber}`,
 				headers: {
 					'Content-Type': "application/x-www-form-urlencoded"
 				}

--- a/server/queue/queue_priv.php
+++ b/server/queue/queue_priv.php
@@ -14,29 +14,10 @@
 		case 'checkIn': checkIn($_REQUEST['time'], $_REQUEST['id']); break;
 		case 'completePaperwork': completePaperwork($_REQUEST['time'], $_REQUEST['id']); break;
 		case 'appointmentStart': appointmentStart($_REQUEST['time'], $_REQUEST['id']); break;
-		case 'appointmentComplete': appointmentComplete($_REQUEST['time'], $_REQUEST['id'], $_REQUEST['servicedById']); break;
+		case 'appointmentComplete': appointmentComplete($_REQUEST['time'], $_REQUEST['id'], $_REQUEST['stationNumber']); break;
 		case 'appointmentIncomplete': appointmentIncomplete($_REQUEST['explanation'], $_REQUEST['id']); break;
 		case 'cancelledAppointment': cancelledAppointment($_REQUEST['id']); break;
-		case 'getVolunteers': getVolunteers($_REQUEST['date'], $_REQUEST['siteId']); break;
 		default: break;
-	}
-
-	function getVolunteers($date, $siteId) {
-		GLOBAL $DB_CONN;
-		$stmt = $DB_CONN->prepare("SELECT User.firstName, User.lastName, User.userId FROM User
-			JOIN UserShift ON User.userId = UserShift.userId
-			JOIN Shift ON UserShift.shiftId = Shift.shiftId
-			WHERE DATE(Shift.startTime) = ?
-				AND Shift.siteId = ?
-				AND Shift.archived = FALSE 
-				AND User.archived = FALSE
-			ORDER BY preparesTaxes DESC"
-		);
-
-		$stmt->execute(array($date, $siteId));
-		$volunteers = $stmt->fetchAll(PDO::FETCH_ASSOC);
-		echo json_encode($volunteers);
-		$stmt = null;
 	}
 
 	function checkIn($time, $id) {
@@ -77,14 +58,14 @@
 		$stmt = null;
 	}
 
-	function appointmentComplete($time, $id, $servicedById) {
+	function appointmentComplete($time, $id, $stationNumber) {
 		$stmt = $GLOBALS['conn']->prepare(
 			"UPDATE ServicedAppointment
-			SET timeAppointmentEnded = ?, completed = TRUE, servicedBy = ?
+			SET timeAppointmentEnded = ?, completed = TRUE, servicedByStation = ?
 			WHERE appointmentId = ?"
 		);
 
-		$stmt->execute(array($time, $servicedById, $id));
+		$stmt->execute(array($time, $stationNumber, $id));
 		$appointment = $stmt->fetchAll(PDO::FETCH_ASSOC);
 		echo json_encode($appointment);
 		$stmt = null;


### PR DESCRIPTION
After discussing with Moody/Vicky today, they thought it would be better if a greeter can select the station number instead of selecting the preparer that prepared the taxes. 

**UPDATES TO PROD DB**
The following script will have to be ran against the PROD database when this is deployed. There should be no impact to running this before, but I would nonetheless prefer waiting. 
```
ALTER TABLE ServicedAppointment DROP FOREIGN KEY ServicedAppointment_ibfk_1;
ALTER TABLE ServicedAppointment DROP COLUMN servicedBy;
ALTER TABLE ServicedAppointment ADD COLUMN servicedByStation INTEGER UNSIGNED NULL;
```

Note that I got the name of that foreign key constraint by running a `SHOW CREATE TABLE ServicedAppointment` which shows you the exact code one could use to recreate the table. Pretty neat.