### PR TITLE
Add hide-wdn_identity_management class to all body tags

### DIFF
--- a/error_pages/404.php
+++ b/error_pages/404.php
@@ -27,7 +27,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/error_pages/500.php
+++ b/error_pages/500.php
@@ -27,7 +27,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/index.template.php
+++ b/index.template.php
@@ -26,7 +26,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/login/index.php
+++ b/login/index.php
@@ -26,7 +26,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/management/documents/index.php
+++ b/management/documents/index.php
@@ -33,7 +33,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/management/index.php
+++ b/management/index.php
@@ -32,7 +32,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/management/users/index.php
+++ b/management/users/index.php
@@ -33,7 +33,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/profile/index.php
+++ b/profile/index.php
@@ -33,7 +33,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/questionnaire/index.php
+++ b/questionnaire/index.php
@@ -29,7 +29,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/queue/index.php
+++ b/queue/index.php
@@ -28,7 +28,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/register/index.php
+++ b/register/index.php
@@ -27,7 +27,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/signup/index.php
+++ b/signup/index.php
@@ -29,7 +29,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/unauthorized/index.php
+++ b/unauthorized/index.php
@@ -27,7 +27,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />

--- a/volunteer/index.php
+++ b/volunteer/index.php
@@ -26,7 +26,7 @@ function wdnInclude($path)
 <!-- TemplateEndEditable -->
 <!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@" data-version="4.1">
+<body class="hide-wdn_identity_management" data-version="4.1">
 	<?php wdnInclude("/wdn/templates_4.1/includes/skipnav.html"); ?>
 	<div id="wdn_wrapper">
 		<input type="checkbox" id="wdn_menu_toggle" value="Show navigation menu" class="wdn-content-slide wdn-input-driver" />


### PR DESCRIPTION
Pretty simple PR. In order to not confuse users, the login button at the top of the pages needed to be removed. This involved adding the ```hide-wdn_identity_management``` class to the body tag of each page, as documented in the [UNL WDN Style Book](https://wdn.unl.edu/unledu-41-style-book#style-book-exceptions).