### PR TITLE
Add in international confirmation message

### DIFF
--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -185,13 +185,47 @@ function generateConfirmation($firstName, $siteId, $appointmentTimeId) {
 	$dateStr = $appointmentTimeInformation['dateStr'];
 	$timeStr = $appointmentTimeInformation['timeStr'];
 
-	$message = "<h2>Appointment Confirmation</h2>".
-			$firstName.", thank you for signing up! Your appointment will be located at the $siteTitle site ($siteAddress). 
-			Please arrive no later than $timeStr on $dateStr with all necessary materials (listed below). 
-			Please call $sitePhoneNumber if you have any questions or would like to reschedule. 
-			Thank you from Lincoln VITA.
-			<h2 class='mt-3'>What to Bring for your Appointment</h2>
-			<h5>Identification:</h5>
+	$message = "<h2>Appointment Confirmation</h2>
+				$firstName, thank you for signing up! Your appointment will be located at the $siteTitle site ($siteAddress). 
+				Please arrive no later than $timeStr on $dateStr with all necessary materials (listed below). 
+				Please call $sitePhoneNumber if you have any questions or would like to reschedule. 
+				Thank you from Lincoln VITA.
+				<h2 class='mt-3'>What to Bring for your Appointment</h2>";
+	if ($siteInformation['doesInternational']) {
+		$message .= internationalInformation(); // If it is an international appointment, there is a different list of what to brings than for residential appointments
+	} else {
+		$message .= residentialInformation();
+	}
+	$message .= "<h5>Miscellaneous:</h5>
+				<ul>
+					<li>Checking or savings account information for direct deposit/direct debit</li>
+					<li>It is <b>STRONGLY RECOMMENDED</b> that you bring last year's tax return</li>
+				</ul>";
+
+	return $message;
+}
+
+function internationalInformation() {
+	return "<h5>Identification:</h5>
+			<ul>
+				<li><b>Social Security card</b> or <b>ITIN Letters</b> for <b>EVERYONE</b> who will be included on the return</li>
+				<li><b>Passport</b> for <b>ALL</b> tax return signers</li>
+			</ul>
+			<h5>Immigration Documents:</h5>
+			<ul>
+				<li><b>I-94</b></li>
+				<li><b>I-20</b></li>
+				<li><b>DS-2019</b> for those in J1 status</li>
+			</ul>
+			<h5>Income:</h5>
+			<ul>
+				<li><b>W-2s</b> for wages</li>
+				<li><b>1042-S</b> (If you received one, not everyone receives one)</li>
+			</ul>";
+}
+
+function residentialInformation() {
+	return "<h5>Identification:</h5>
 			<ul>
 				<li><b>Social Security cards</b> or <b>ITIN Letters</b> for <b>EVERYONE</b> who will be included on the return</li>
 				<li><b>Photo ID</b> for <b>ALL</b> tax return signers (BOTH spouses must sign if filing jointly)</li>
@@ -212,20 +246,13 @@ function generateConfirmation($firstName, $siteId, $appointmentTimeId) {
 				<li><b>Statement of college student account</b> showing all charges and payments for each student on the return</li>
 				<li><b>Childcare receipts</b>, including tax ID and address for childcare provider</li>
 				<li><b>Records</b> of expenses for self-employment or home-based businesses</li>
-			</ul>
-			<h5>Miscellaneous:</h5>
-			<ul>
-				<li>Checking or savings account information for direct deposit/direct debit</li>
-				<li>It is <b>STRONGLY RECOMMENDED</b> that you bring last year's tax return</li>
 			</ul>";
-
-	return $message;
 }
 
 function getSiteInformation($siteId) {
 	GLOBAL $DB_CONN;
 
-	$query = "SELECT address, phoneNumber, title 
+	$query = "SELECT address, phoneNumber, title, doesInternational
 		FROM Site 
 		WHERE siteId = ?";
 	$stmt = $DB_CONN->prepare($query);


### PR DESCRIPTION
Since international appointments have a different list of things to bring, we added the functionality that changes the appointment confirmation message depending on if an appointment is international or not. 

**TESTING**
* You probably need to add an AppointmentTime for the international site, the below query will add one for February 23rd, 2018
```
INSERT INTO AppointmentTime (scheduledTime, maximumNumberOfAppointments, percentageAppointments, siteId)
	VALUES ('2018-02-23 13:00:00', 10, 100, 7);
```
* Sign up for an appointment as a residential appointment
  * You should see the appointment confirmation we are used to seeing
* Sign up for an international appointment
  * You should see the new international appointment confirmation list