### PR TITLE
Create report to show appointment filing statuses

### DIFF
--- a/management/documents/documents.js
+++ b/management/documents/documents.js
@@ -3,6 +3,7 @@ WDN.initializePlugin('jqueryui', [function () {
 		$(document).ready(function() {
 			window.downloadAppointmentSchedule = downloadAppointmentSchedule;
 			window.downloadVolunteerSchedule = downloadVolunteerSchedule;
+			window.downloadAppointmentsFilingStatuses = downloadAppointmentsFilingStatuses;
 
 			loadAllSites();
 
@@ -26,6 +27,12 @@ WDN.initializePlugin('jqueryui', [function () {
 			let date = getSelectedDate();
 			clickDownloadLink(`/server/management/documents/volunteerSchedule.php?date=${date}&siteId=${siteId}`);
 		};
+		
+		function downloadAppointmentsFilingStatuses() {
+			let siteId = getSelectedSiteId();
+			let date = getSelectedDate();
+			clickDownloadLink(`/server/management/documents/appointmentsFilingStatuses.php?date=${date}&siteId=${siteId}`);
+		}
 
 		function getSelectedSiteId() {
 			let siteSelect = document.getElementById("siteSelect");

--- a/management/documents/index.php
+++ b/management/documents/index.php
@@ -103,6 +103,7 @@ function wdnInclude($path)
 						<div class="wdn-col">
 							<button class="wdn-button mt-1rem" onclick="downloadAppointmentSchedule();">Download Appointment Schedule</button>
 							<button class="wdn-button mt-1rem" onclick="downloadVolunteerSchedule();">Download Volunteer Schedule</button>
+							<button class="wdn-button mt-1rem" onclick="downloadAppointmentsFilingStatuses();">Download Appointments Filing Statuses</button>
 						</div>
 					</form>
 				</div>

--- a/server/management/documents/appointmentsFilingStatuses.php
+++ b/server/management/documents/appointmentsFilingStatuses.php
@@ -1,0 +1,144 @@
+<?php
+
+$root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
+if (!$USER->hasPermission('use_admin_tools')) {
+	header("Location: /unauthorized");
+	die();
+}
+$HEADER_COLUMN_NAMES = array('First Name', 'Last Name', 'Appointment ID', 'Appointment Completed', 'Reason if Not Completed', 'State E-File', 'Federal E-File', 'State Paper', 'Federal Paper');
+$ALL_SITES_ID = -1;
+
+require_once "$root/server/config.php";
+require_once "$root/server/libs/wrappers/PHPExcelWrapper.class.php";
+
+getAppointmentsFilingStatusesExcelFile($_GET);
+
+function getAppointmentsFilingStatusesExcelFile($data) {
+	$appointments = executeAppointmentQuery($data);
+	$phpExcelWrapper = createAppointmentsFilingStatusesExcelFile($appointments);
+
+	ob_clean();
+	ob_end_clean();
+
+	$fileName = $data['date'] . '_AppointmentFilingStatuses' . '.xlsx';
+	header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+	header('Content-Disposition: attachment;filename="'. $fileName .'"');
+	header('Cache-Control: max-age=0');
+	header ('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+	header ('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+	header ('Cache-Control: cache, must-revalidate');
+	header ('Pragma: public');
+
+	$objWriter = $phpExcelWrapper->createExcelWriter();
+	$objWriter->save('php://output');
+
+	exit;
+}
+
+function executeAppointmentQuery($data) {
+	GLOBAL $DB_CONN, $ALL_SITES_ID;
+
+	$query = 'SELECT Client.firstName, Client.lastName, Appointment.appointmentId,
+		ServicedAppointment.completed, ServicedAppointment.notCompletedDescription, ServicedAppointment.servicedAppointmentId,
+		Site.title
+		FROM Appointment
+		LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
+		JOIN Client ON Appointment.clientId = Client.clientId
+		JOIN AppointmentTime ON Appointment.appointmentTimeId = AppointmentTime.appointmentTimeId
+		JOIN Site ON AppointmentTime.siteId = Site.siteId
+		WHERE DATE(AppointmentTime.scheduledTime) = ?
+			AND Appointment.archived = FALSE';
+	if ($data['siteId'] != $ALL_SITES_ID) {
+		$query .= ' AND AppointmentTime.siteId = ?';
+	}
+	$query .= ' ORDER BY AppointmentTime.siteId ASC, AppointmentTime.scheduledTime ASC';
+	$stmt = $DB_CONN->prepare($query);
+
+	$filterParams = array($data['date']);
+	if ($data['siteId'] != $ALL_SITES_ID) {
+		$filterParams[] = $data['siteId'];
+	}
+	$stmt->execute($filterParams);
+	$appointments = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+
+	$filingStatusQuery = 'SELECT lookupName 
+		FROM AppointmentFilingStatus
+		JOIN FilingStatus ON AppointmentFilingStatus.filingStatusId = FilingStatus.filingStatusId
+		WHERE AppointmentFilingStatus.servicedAppointmentId = ?';
+	$stmt = $DB_CONN->prepare($filingStatusQuery);
+	foreach ($appointments as &$appointment) {
+		$appointment['stateEFile'] = false;
+		$appointment['federalEFile'] = false;
+		$appointment['statePaper'] = false;
+		$appointment['federalPaper'] = false;
+
+		if (!isset($appointment['servicedAppointmentId'])) continue;
+
+		$stmt->execute(array($appointment['servicedAppointmentId']));
+		$filingStatuses = $stmt->fetchAll(PDO::FETCH_ASSOC);
+		foreach ($filingStatuses as $filingStatus) {
+			if ($filingStatus['lookupName'] === 'state_efile') $appointment['stateEFile'] = true;
+			else if ($filingStatus['lookupName'] === 'federal_efile') $appointment['federalEFile'] = true;
+			else if ($filingStatus['lookupName'] === 'state_paper') $appointment['statePaper'] = true;
+			else if ($filingStatus['lookupName'] === 'federal_paper') $appointment['federalPaper'] = true;
+		}
+	}
+
+	return $appointments;
+}
+
+function createAppointmentsFilingStatusesExcelFile($appointments) {
+	GLOBAL $HEADER_COLUMN_NAMES;
+	$phpExcelWrapper = new PHPExcelWrapper();
+
+	if (empty($appointments)) {
+		$sheetIndex = $phpExcelWrapper->createSheet('None');
+		$phpExcelWrapper->setActiveSheetIndex($sheetIndex);
+		$phpExcelWrapper->insertHeaderRow($HEADER_COLUMN_NAMES);
+		$phpExcelWrapper->nextRow();
+	} else {
+		# Iterate through all the results and append them to the proper sheet
+		$sheetIndexForSiteId = array();
+		foreach ($appointments as $row) {
+			$siteId = $row['siteId'];
+
+			# Add in the sheet for the site if it doesn't already exist
+			if (!isset($sheetIndexForSiteId[$siteId])) {
+				$sheetIndex = $phpExcelWrapper->createSheet($row['title']);
+				$sheetIndexForSiteId[$siteId] = $sheetIndex;
+
+				$phpExcelWrapper->setActiveSheetIndex($sheetIndex);
+				$phpExcelWrapper->insertHeaderRow($HEADER_COLUMN_NAMES);
+				$phpExcelWrapper->nextRow();
+			}
+
+			# Grab current sheet index
+			$sheetIndex = $sheetIndexForSiteId[$siteId];
+			$phpExcelWrapper->setActiveSheetIndex($sheetIndex);
+
+			# Insert Appointment Data
+			foreach ($row as $key => $value) {
+				if ($key === 'siteId' || $key === 'title' || $key === 'servicedAppointmentId') continue;
+				if (!$value) $row[$key] = ''; # Change any null data to just be an empty string
+				if ($key === 'stateEFile' || $key === 'federalEFile' || $key === 'statePaper' || $key === 'federalPaper') {
+					$row[$key] = ($value == true ? 'Yes' : '');
+				}
+				if ($key === 'completed') {
+					$row[$key] = ($value == true ? 'Yes' : 'No');
+				}
+
+				$phpExcelWrapper->insertData($row[$key]);
+				$phpExcelWrapper->nextColumn();
+			}
+			$phpExcelWrapper->nextRow();
+		}
+	}
+
+	# Set the default sheet to the first one
+	$phpExcelWrapper->setActiveSheetIndex(0);
+
+	return $phpExcelWrapper;
+}

--- a/server/management/documents/appointmentsFilingStatuses.php
+++ b/server/management/documents/appointmentsFilingStatuses.php
@@ -42,7 +42,7 @@ function executeAppointmentQuery($data) {
 
 	$query = 'SELECT Client.firstName, Client.lastName, Appointment.appointmentId,
 		ServicedAppointment.completed, ServicedAppointment.notCompletedDescription, ServicedAppointment.servicedAppointmentId,
-		Site.title
+		Site.title, Site.siteId
 		FROM Appointment
 		LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
 		JOIN Client ON Appointment.clientId = Client.clientId

--- a/server/management/users/users.php
+++ b/server/management/users/users.php
@@ -240,7 +240,7 @@ function addUser($data){
 		$res = $stmt->execute(array(
 			$data['firstName'],
 			$data['lastName'],
-			$data['email'],
+			trim($data['email']),
 			$data['phone']
 		));
 


### PR DESCRIPTION
This creates a report that enables a volunteer to see the filing status of appointments that were serviced on a certain day.

**TESTING**
* Log in as siteadmin
* Go to the queue, and complete a few appointments
  * Select various filing statuses
  * Cancel an appointment
  * Incomplete an appointment with a reason
* Go to Print Documents, and hit the "Download Appointments FilingStatuses" button
  * Open the report. You should see a report that contains the appointment with whether or not it was completed, and the filing statuses.