### PR TITLE
Fix overlapping shift time bug causing double appointments allotted during time

### DIFF
--- a/mysql_scripts/production_data/FullDBProdData.sql
+++ b/mysql_scripts/production_data/FullDBProdData.sql
@@ -142,24 +142,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-01-24 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-24 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-24 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-24 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-24 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -277,24 +277,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-01-30 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-30 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-30 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-30 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-30 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Wednesday, NEU
@@ -328,24 +328,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-01-31 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-31 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-31 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-31 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-01-31 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -462,24 +462,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-06 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-06 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-06 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-06 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-06 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Wednesday, NEU
@@ -512,24 +512,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-07 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-07 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-07 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-07 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-07 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -646,24 +646,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-13 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-13 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-13 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-13 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-13 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Wednesday, NEU
@@ -696,24 +696,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-14 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-14 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-14 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-14 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-14 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -831,24 +831,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-20 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-20 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-20 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-20 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-20 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Wednesday, NEU
@@ -881,24 +881,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-21 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-21 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-21 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-21 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-21 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -1015,24 +1015,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-27 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-27 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-27 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-27 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-27 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Wednesday, NEU
@@ -1065,24 +1065,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-02-28 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-28 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-28 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-28 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-02-28 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -1152,24 +1152,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-06 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-06 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-06 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-06 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-06 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 -- Tuesday, ISS
 SET @shiftStartTime = "2018-03-06 13:00:00";
@@ -1210,24 +1210,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-07 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-07 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-07 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-07 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-07 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Saturday
@@ -1297,24 +1297,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-13 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-13 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-13 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-13 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-13 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 -- Tuesday, ISS
 SET @shiftStartTime = "2018-03-13 13:00:00";
@@ -1355,24 +1355,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-14 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-14 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-14 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-14 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-14 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Tuesday, AL
@@ -1382,24 +1382,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-20 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-20 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-20 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-20 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-20 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 -- Tuesday, ISS
 SET @shiftStartTime = "2018-03-20 13:00:00";
@@ -1427,24 +1427,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-21 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-21 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-21 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-21 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-21 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Tuesday, AL
@@ -1454,24 +1454,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-27 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-27 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-27 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-27 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-27 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 -- Tuesday, ISS
 SET @shiftStartTime = "2018-03-27 13:00:00";
@@ -1512,24 +1512,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-03-28 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-28 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-28 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-28 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-03-28 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Sunday
@@ -1542,24 +1542,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-04-03 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-03 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-03 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-03 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-03 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 -- Tuesday, ISS
 SET @shiftStartTime = "2018-04-03 13:00:00";
@@ -1600,24 +1600,24 @@ INSERT INTO Shift (startTime, endTime, siteId, createdBy, lastModifiedBy)
 	VALUES (@shiftStartTime, @shiftEndTime, @site_andersonLibrary, @userId, @userId);
 
 SET @scheduledTime = "2018-04-04 16:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-04 17:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-04 17:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-04 18:00:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 SET @scheduledTime = "2018-04-04 18:30:00";
-INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId)
-	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary);
+INSERT INTO AppointmentTime (scheduledTime, minimumNumberOfAppointments, maximumNumberOfAppointments, siteId, approximateLengthInMinutes)
+	VALUES (@scheduledTime, 3, 3, @site_andersonLibrary, 30);
 
 
 -- Sunday

--- a/mysql_scripts/table_creation/FullDB.sql
+++ b/mysql_scripts/table_creation/FullDB.sql
@@ -5,7 +5,6 @@ DROP TABLE IF EXISTS AppointmentFilingStatus;
 DROP TABLE IF EXISTS FilingStatus;
 DROP TABLE IF EXISTS ServicedAppointment;
 DROP TABLE IF EXISTS Appointment;
-DROP TABLE IF EXISTS DependentClient;
 DROP TABLE IF EXISTS AppointmentTime;
 DROP TABLE IF EXISTS Client;
 DROP TABLE IF EXISTS UserShift;
@@ -78,6 +77,7 @@ CREATE TABLE AppointmentTime (
 	minimumNumberOfAppointments INTEGER UNSIGNED DEFAULT 0,
 	maximumNumberOfAppointments INTEGER UNSIGNED DEFAULT NULL,
 	percentageAppointments INTEGER UNSIGNED NOT NULL DEFAULT 100,
+	approximateLengthInMinutes INTEGER UNSIGNED NOT NULL DEFAULT 60,
 	CONSTRAINT percentageCheck CHECK (percentageAppointments>=0 AND percentageAppointments<=100),
 	siteId INTEGER UNSIGNED NOT NULL,
 	FOREIGN KEY(siteId) REFERENCES Site(siteId)

--- a/server/api/appointments/getTimes.php
+++ b/server/api/appointments/getTimes.php
@@ -36,7 +36,7 @@ function getAppointmentTimes($data, $isLoggedIn) {
 	$query = 'SELECT apt.appointmentTimeId, apt.siteId, s.title, DATE(scheduledTime) AS scheduledDate, TIME(scheduledTime) AS scheduledTime, percentageAppointments, COUNT(DISTINCT a.appointmentId) AS numberOfAppointmentsAlreadyMade, COUNT(DISTINCT us.userShiftId) AS numberOfPreparers, apt.minimumNumberOfAppointments, apt.maximumNumberOfAppointments
 	FROM AppointmentTime apt
 	LEFT JOIN Appointment a ON a.appointmentTimeId = apt.appointmentTimeId
-	LEFT JOIN UserShift us ON us.shiftId IN (SELECT s.shiftId FROM Shift s WHERE s.siteId = apt.siteId AND s.startTime <= apt.scheduledTime AND s.endTime >= apt.scheduledTime) 
+	LEFT JOIN UserShift us ON us.shiftId IN (SELECT s.shiftId FROM Shift s WHERE s.siteId = apt.siteId AND s.startTime <= apt.scheduledTime AND s.endTime >= apt.scheduledTime AND s.endTime - apt.scheduledTime >= 60) 
 		AND us.roleId = (SELECT roleId FROM Role WHERE lookupName = "preparer")
 	LEFT JOIN Site s ON s.siteId = apt.siteId
 	WHERE YEAR(apt.scheduledTime) = ? 

--- a/server/api/appointments/getTimes.php
+++ b/server/api/appointments/getTimes.php
@@ -36,7 +36,7 @@ function getAppointmentTimes($data, $isLoggedIn) {
 	$query = 'SELECT apt.appointmentTimeId, apt.siteId, s.title, DATE(scheduledTime) AS scheduledDate, TIME(scheduledTime) AS scheduledTime, percentageAppointments, COUNT(DISTINCT a.appointmentId) AS numberOfAppointmentsAlreadyMade, COUNT(DISTINCT us.userShiftId) AS numberOfPreparers, apt.minimumNumberOfAppointments, apt.maximumNumberOfAppointments
 	FROM AppointmentTime apt
 	LEFT JOIN Appointment a ON a.appointmentTimeId = apt.appointmentTimeId
-	LEFT JOIN UserShift us ON us.shiftId IN (SELECT s.shiftId FROM Shift s WHERE s.siteId = apt.siteId AND s.startTime <= apt.scheduledTime AND s.endTime >= apt.scheduledTime AND s.endTime - apt.scheduledTime >= 60) 
+	LEFT JOIN UserShift us ON us.shiftId IN (SELECT s.shiftId FROM Shift s WHERE s.siteId = apt.siteId AND s.startTime <= apt.scheduledTime AND s.endTime >= apt.scheduledTime AND TIMESTAMPDIFF(MINUTE, apt.scheduledTime, s.endTime) >= apt.approximateLengthInMinutes) 
 		AND us.roleId = (SELECT roleId FROM Role WHERE lookupName = "preparer")
 	LEFT JOIN Site s ON s.siteId = apt.siteId
 	WHERE YEAR(apt.scheduledTime) = ? 


### PR DESCRIPTION
This PR attempts to fix the issue where during the 30-minute shift overlap, double the number of appointments are able to be scheduled (since it sees there are double the volunteers during that time). 

I'm not certain that this actually works. I'm having a hard time testing it on local test data or against prod SQL database. If nothing else, I don't think this will have an effect, but please use your vast SQL knowledge and determine if you think I've done this right.

**UPDATE**
I was able to test this against prod data and it functioned successfully. In the first one, I had made the naive mistake of assuming that subtracting two datetimes would yield the difference in minutes... idk what I was thinking. I'm not sure what the subtraction of two datetimes is, but it was something very large every time, so that old query was almost always true. This new one uses `TIMESTAMPDIFF(MINUTES, ...)` which _will_ return the difference in minutes and make this work properly. 
Also, I am open to changing the name of the field that I added, I wanted to capture that it was stored in minutes in the name, and also that it's not necessarily an exact appointment length time, and so `approximateLengthInMinutes` was the best I could come up with.

**CHANGES TO PROD DB**
The following SQL script needs to be run before this is deployed.
```
ALTER TABLE AppointmentTime
	ADD COLUMN approximateLengthInMinutes INTEGER UNSIGNED NOT NULL DEFAULT 60;
```