### PR TITLE
Add more information to appointment management page

### DIFF
--- a/management/appointments/appointments.css
+++ b/management/appointments/appointments.css
@@ -6,6 +6,10 @@
 	color: red;
 }
 
+.status-in-progress {
+	color: #3399ff;
+}
+
 .status-complete {
 	color: green;
 }

--- a/management/appointments/appointments.css
+++ b/management/appointments/appointments.css
@@ -2,6 +2,14 @@
 	cursor: pointer;
 }
 
+.status-incomplete {
+	color: red;
+}
+
+.status-complete {
+	color: green;
+}
+
 /* Switch code adapted from https://www.w3schools.com/howto/howto_css_switch.asp */
 
 /* The switch - the box around the slider */

--- a/management/appointments/appointments.php
+++ b/management/appointments/appointments.php
@@ -24,7 +24,10 @@
 		</div>
 
 		<div class="wdn-col-one-half">
-			<div><b>Status: </b><span ng-class="appointment.completed ? 'status-complete' : 'status-incomplete'">{{appointment.statusText}}</span></div>
+			<div><b>Status: </b><span 
+				ng-class="{'status-in-progress': appointment.inProgress || appointment.notStarted, 'status-incomplete': appointment.incomplete || appointment.cancelled, 'status-complete': appointment.completed}">
+				{{appointment.statusText}}
+			</span></div>
 			<div><b>Time Arrived: </b>{{appointment.timeIn != null ? appointment.timeIn : "N/A"}}</div>
 			<div><b>Time Paperwork Completed: </b>{{appointment.timeReturnedPapers != null ? appointment.timeReturnedPapers : "N/A"}}</div>
 			<div><b>Time Appointment Started: </b>{{appointment.timeAppointmentStarted != null ? appointment.timeAppointmentStarted : "N/A"}}</div>

--- a/management/appointments/appointments.php
+++ b/management/appointments/appointments.php
@@ -8,16 +8,37 @@
 
 	<!-- Information Section -->
 	<h2 class="client-name">{{appointment.firstName}} {{appointment.lastName}}</h2>
-	<div><b>Scheduled Appointment Time: </b>{{appointment.scheduledTime}}</div>
-	<div><b>Site: </b>{{appointment.title}}</div>
-	<div><b>Requested Language: </b>{{appointment.language}}</div>
-	<div ng-if="appointment.emailAddress != null">
-		<span><b>Email: </b>{{appointment.emailAddress}}</span>
+	<div class="wdn-grid-set">
+
+		<div class="wdn-col-one-half">
+			<div><b>Scheduled Appointment Time: </b>{{appointment.scheduledTime}}</div>
+			<div><b>Site: </b>{{appointment.title}}</div>
+			<div><b>Requested Language: </b>{{appointment.language}}</div>
+			<div ng-if="appointment.emailAddress != null">
+				<span><b>Email: </b>{{appointment.emailAddress}}</span>
+			</div>
+			<div ng-if="appointment.phoneNumber != null">
+				<span><b>Phone Number: </b>{{appointment.phoneNumber}}</span>
+			</div>
+			<div><b>Appointment ID: </b>{{appointment.appointmentId}}</div>
+		</div>
+
+		<div class="wdn-col-one-half">
+			<div><b>Status: </b><span ng-class="appointment.completed ? 'status-complete' : 'status-incomplete'">{{appointment.statusText}}</span></div>
+			<div><b>Time Arrived: </b>{{appointment.timeIn != null ? appointment.timeIn : "N/A"}}</div>
+			<div><b>Time Paperwork Completed: </b>{{appointment.timeReturnedPapers != null ? appointment.timeReturnedPapers : "N/A"}}</div>
+			<div><b>Time Appointment Started: </b>{{appointment.timeAppointmentStarted != null ? appointment.timeAppointmentStarted : "N/A"}}</div>
+			<div><b>Time Appointment Ended: </b>{{appointment.timeAppointmentEnded != null ? appointment.timeAppointmentEnded : "N/A"}}</div>
+			<div><b>Prepared at Station: </b>{{appointment.servicedByStation != null ? appointment.servicedByStation : "N/A"}}</div>
+		</div>
 	</div>
-	<div ng-if="appointment.phoneNumber != null">
-		<span><b>Phone Number: </b>{{appointment.phoneNumber}}</span>
+	<div ng-if="appointment.notCompletedDescription != null"><b>Not Completed Reason: </b>{{appointment.notCompletedDescription}}</div>
+	<div ng-if="appointment.filingStatuses.length > 0">
+		<div><b>Filed: </b></div>
+		<ul>
+			<li ng-repeat="filingStatus in appointment.filingStatuses">{{filingStatus.text}}</li>
+		</ul>
 	</div>
-	<div><b>Appointment ID: </b>{{appointment.appointmentId}}</div>
 
 	<!-- Reschedule Section -->
 	<h3>Reschedule Appointment</h3>

--- a/management/appointments/appointmentsController.js
+++ b/management/appointments/appointmentsController.js
@@ -23,14 +23,14 @@ define('appointmentsController', [], function() {
 							appointment.completed = appointment.completed == true; // Do this since the SQL returns 0/1, and we want it to be false/true
 							
 							appointment.cancelled = appointment.notCompletedDescription === "Cancelled Appointment";
-							appointment.incomplete = appointment.completed === false;
-							appointment.inProgress = appointment.incomplete && appointment.timeIn != null;
 							appointment.notStarted = !appointment.cancelled && appointment.timeIn == null;
+							appointment.incomplete = !appointment.cancelled && appointment.notCompletedDescription != null;
+							appointment.inProgress = !appointment.cancelled && !appointment.incomplete && appointment.timeIn != null && !appointment.completed;
 							
 							if (appointment.completed) appointment.statusText = "Complete";
 							else if (appointment.cancelled) appointment.statusText = "Cancelled";
-							else if (appointment.inProgress) appointment.statusText = "In Progress";
 							else if (appointment.notStarted) appointment.statusText = "Not Started";
+							else if (appointment.inProgress) appointment.statusText = "In Progress";
 							else if (appointment.incomplete) appointment.statusText = "Incomplete";
 							else appointment.statusText = "Unknown";
 

--- a/management/appointments/appointmentsController.js
+++ b/management/appointments/appointmentsController.js
@@ -20,6 +20,14 @@ define('appointmentsController', [], function() {
 					if (result.appointments.length > 0) {
 						$scope.appointments = result.appointments.map((appointment) => {
 							appointment.name = appointment.firstName + " " + appointment.lastName;
+							appointment.completed = appointment.completed == true; // Do this since the SQL returns 0/1, and we want it to be false/true
+							
+							appointment.statusText = "Complete";
+							if (!appointment.completed) {
+								if (appointment.notCompletedDescription === "Cancelled Appointment") appointment.statusText = "Cancelled";
+								else appointment.statusText = "Incomplete";
+							}
+
 							return appointment;
 						});
 					} else {

--- a/management/appointments/appointmentsController.js
+++ b/management/appointments/appointmentsController.js
@@ -22,11 +22,17 @@ define('appointmentsController', [], function() {
 							appointment.name = appointment.firstName + " " + appointment.lastName;
 							appointment.completed = appointment.completed == true; // Do this since the SQL returns 0/1, and we want it to be false/true
 							
-							appointment.statusText = "Complete";
-							if (!appointment.completed) {
-								if (appointment.notCompletedDescription === "Cancelled Appointment") appointment.statusText = "Cancelled";
-								else appointment.statusText = "Incomplete";
-							}
+							appointment.cancelled = appointment.notCompletedDescription === "Cancelled Appointment";
+							appointment.incomplete = appointment.completed === false;
+							appointment.inProgress = appointment.incomplete && appointment.timeIn != null;
+							appointment.notStarted = !appointment.cancelled && appointment.timeIn == null;
+							
+							if (appointment.completed) appointment.statusText = "Complete";
+							else if (appointment.cancelled) appointment.statusText = "Cancelled";
+							else if (appointment.inProgress) appointment.statusText = "In Progress";
+							else if (appointment.notStarted) appointment.statusText = "Not Started";
+							else if (appointment.incomplete) appointment.statusText = "Incomplete";
+							else appointment.statusText = "Unknown";
 
 							return appointment;
 						});


### PR DESCRIPTION
Added more information to an appointment on the appointment management page. 

**TESTING**
* Log in
* Go to queue page
  * Complete an appointment and record the client's name
  * Submit a cancelled appointment and record the client's name
  * Submit an incomplete appointment with a reason and record the client's name
  * Check in and paperwork complete an appointment and record the client's name
* Go to the appointment management page
  * Search for the completed client's name and click on that appointment
    * The status should be green and say "Complete"
    * All the time information on the right should be there (none should be N/A)
    * The Serviced at Station should be there
    * The Filing statuses you chose should be displayed
  * Search for the cancelled client's name and click on that appointment
    * The status should be red and say "Cancelled"
    * All the time information should be N/A
    * The Not Completed Description section should be there with "Cancelled Appointment" reason
  * Search for the incomplete client's name and click on that appointment
    * The status should be red and say "Incomplete"
    * The time information for how far you went should be there and the rest should be N/A
    * The Not Completed Description section should be there with the reason you gave
  * Search for the somewhat complete client's name and click on that appointment
    * The status should be blueish and say "In Progress"
    * The time information for how far you went should be there and the rest should be N/A
  * Click on any other appointment 
    * The status should be blueish and say "Not Started"
    * The time information should all be N/A