### PR TITLE
203 cancel appointment

### DIFF
--- a/management/appointments/appointments.php
+++ b/management/appointments/appointments.php
@@ -35,7 +35,7 @@
 			<div><b>Prepared at Station: </b>{{appointment.servicedByStation != null ? appointment.servicedByStation : "N/A"}}</div>
 		</div>
 	</div>
-	<div ng-if="appointment.notCompletedDescription != null"><b>Not Completed Reason: </b>{{appointment.notCompletedDescription}}</div>
+	<div ng-show="appointment.notCompletedDescription != null"><b>Not Completed Reason: </b>{{appointment.notCompletedDescription}}</div>
 	<div ng-if="appointment.filingStatuses.length > 0">
 		<div><b>Filed: </b></div>
 		<ul>
@@ -62,6 +62,15 @@
 			ng-model="submittingReschedule" 
 			ng-click="rescheduleAppointment()">
 	</form>
+
+	<!-- Cancel Button -->
+	<button type="button" 
+		value="Cancel"
+		id="cancelButton"
+		class="submit wdn-button wdn-button-brand"
+		ng-show="appointment.notStarted && !appointment.cancelled"
+		ng-click="cancelAppointment()">Cancel Appointment</button>
+
 </div>
 
 <!-- Show if no selected appointment -->

--- a/management/appointments/appointments.php
+++ b/management/appointments/appointments.php
@@ -61,15 +61,15 @@
 			ng-disabled="sharedProperties.selectedDate == null || sharedProperties.selectedSite == null || sharedProperties.selectedTime == null || submittingReschedule" 
 			ng-model="submittingReschedule" 
 			ng-click="rescheduleAppointment()">
-	</form>
 
-	<!-- Cancel Button -->
-	<button type="button" 
-		value="Cancel"
-		id="cancelButton"
-		class="submit wdn-button wdn-button-brand"
-		ng-show="appointment.notStarted && !appointment.cancelled"
-		ng-click="cancelAppointment()">Cancel Appointment</button>
+		<!-- Cancel Button -->
+		<button type="button" 
+			value="Cancel"
+			id="cancelButton"
+			class="submit wdn-button wdn-button-brand"
+			ng-show="appointment.notStarted && !appointment.cancelled"
+			ng-click="cancelAppointment()">Cancel Appointment</button>
+	</form>
 
 </div>
 

--- a/management/appointments/appointmentsController.js
+++ b/management/appointments/appointmentsController.js
@@ -68,7 +68,7 @@ define('appointmentsController', [], function() {
 					$scope.submittingReschedule = false;
 					
 					// Let the user know it was successful
-					$scope.giveNotice("Success!", "This appointment was successfully rescheduled.", true);
+					$scope.giveNotice("Success!", "This appointment was successfully rescheduled.");
 				} else {
 					alert(result.error);
 

--- a/management/appointments/appointmentsController.js
+++ b/management/appointments/appointmentsController.js
@@ -4,6 +4,7 @@ define('appointmentsController', [], function() {
 
 		$scope.sharedProperties = sharedPropertiesService.getSharedProperties();
 		$scope.submittingReschedule = false;
+		$scope.cancelling = false;
 
 		$scope.getAppointments = function() {
 			let year = new Date().getFullYear();
@@ -67,39 +68,44 @@ define('appointmentsController', [], function() {
 					$scope.submittingReschedule = false;
 					
 					// Let the user know it was successful
-					WDN.initializePlugin('notice');
-					var body = angular.element( document.querySelector( 'body' ) );
-					body.append(`
-						<div class="wdn_notice affirm" data-overlay="maincontent" data-duration="10">
-							<div class="close">
-								<a href="#">Close this notice</a>
-							</div>
-							<div class="message">
-								<p class="title">Success!</p>
-								<p>This appointment was successfully rescheduled.</a>
-								</p>
-							</div>
-						</div>`);  
+					$scope.giveNotice("Success!", "This appointment was successfully rescheduled.", true);
 				} else {
 					alert(result.error);
 
 					$scope.submittingReschedule = false;
 
 					// Let the user know it failed
-					WDN.initializePlugin('notice');
-					var body = angular.element( document.querySelector( 'body' ) );
-					body.append(`
-						<div class="wdn_notice negate" data-overlay="maincontent" data-duration="10">
-							<div class="close">
-								<a href="#">Close this notice</a>
-							</div>
-							<div class="message">
-								<p class="title">Failure</p>
-								<p>Something went wrong and this appointment was not rescheduled!</a>
-								</p>
-							</div>
-						</div>`);
+					$scope.giveNotice("Failure", "Something went wrong and this appointment was not rescheduled!", false);
 				}
+			});
+		}
+
+		$scope.cancelAppointment = function() {
+			if ($scope.cancelling) return false;
+
+			$scope.cancelling = true;
+
+			const appointmentId = $scope.appointment.appointmentId;
+			AppointmentsService.cancelAppointment(appointmentId).then(function(result) {
+				if (result.success) {
+					document.body.scrollTop = document.documentElement.scrollTop = 0;
+
+					$scope.appointment.cancelled = true;
+					$scope.appointment.notStarted = false;
+					$scope.appointment.statusText = "Cancelled";
+					$scope.appointment.notCompletedDescription = "Cancelled Appointment";
+
+					// Let the user know it was successful
+					$scope.giveNotice("Success!", "This appointment was successfully cancelled.", true);
+				} else {
+					document.body.scrollTop = document.documentElement.scrollTop = 0;
+					alert(result.error);
+
+					// Let the user know it failed
+					$scope.giveNotice("Failure", "Something went wrong and this appointment was not cancelled!", false);
+				}
+
+				$scope.cancelling = false;
 			});
 		}
 
@@ -109,6 +115,22 @@ define('appointmentsController', [], function() {
 
 		$scope.deselectAppointment = function() {
 			$scope.appointment = null;
+		}
+
+		$scope.giveNotice = function(title, message, affirmative = true) {
+			WDN.initializePlugin('notice');
+			var body = angular.element( document.querySelector( 'body' ) );
+			body.append(`
+				<div class="wdn_notice ${affirmative ? 'affirm' : 'negate'}" data-overlay="maincontent" data-duration="10">
+					<div class="close">
+						<a href="#">Close this notice</a>
+					</div>
+					<div class="message">
+						<p class="title">${title}</p>
+						<p>${message}</a>
+						</p>
+					</div>
+				</div>`);
 		}
 
 		// Invoke initially

--- a/management/appointments/appointmentsDataService.js
+++ b/management/appointments/appointmentsDataService.js
@@ -22,6 +22,20 @@ define('appointmentsDataService', [], function($http) {
 				},function(error){
 					return null;
 				});
+			},
+			cancelAppointment: function(appointmentId) {
+				return $http({
+					url: "/server/management/appointments/appointments.php",
+					method: 'POST',
+					data: `action=cancel&id=${appointmentId}`,
+					headers: {
+						'Content-Type': "application/x-www-form-urlencoded"
+					}
+				}).then(function(response){
+					return response.data;
+				},function(error){
+					return null;
+				});
 			}
 		}
 	}

--- a/server/accessors/AppointmentManager.class.php
+++ b/server/accessors/AppointmentManager.class.php
@@ -1,0 +1,20 @@
+<?php
+
+$root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/config.php";
+
+class AppointmentManager {
+
+	public function cancelAppointment($appointmentId) {
+		GLOBAL $DB_CONN;
+
+		$query = "INSERT INTO ServicedAppointment (appointmentId, notCompletedDescription, completed)
+			VALUES (?, 'Cancelled Appointment', FALSE)";
+		$stmt = $DB_CONN->prepare($query);
+
+		if ($stmt->execute(array($appointmentId)) == false) {
+			throw new Exception('Unable to cancel the appointment.', MY_EXCEPTION);
+		}
+	}
+
+}

--- a/server/accessors/appointmentAccessor.class.php
+++ b/server/accessors/appointmentAccessor.class.php
@@ -3,8 +3,11 @@
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
 require_once "$root/server/config.php";
 
-class AppointmentManager {
+class AppointmentAccessor {
 
+	/**
+	 * Note that this method assumes no ServicedAppointment entry has been created for this appointment
+	 */
 	public function cancelAppointment($appointmentId) {
 		GLOBAL $DB_CONN;
 

--- a/server/management/appointments/appointments.php
+++ b/server/management/appointments/appointments.php
@@ -9,11 +9,13 @@ if (!$USER->isLoggedIn()) {
 }
 
 require_once "$root/server/config.php";
+require_once "$root/server/accessors/appointmentAccessor.class.php";
 
 if (isset($_REQUEST['action'])) {
 	switch ($_REQUEST['action']) {
 		case 'getAppointments': getAppointments($_GET['year']); break;
 		case 'reschedule': rescheduleAppointment($_POST['id'], $_POST['appointmentTimeId']); break;
+		case 'cancel': cancelAppointment($_POST['id']); break;
 		default:
 			die('Invalid action function. This instance has been reported.');
 			break;
@@ -102,6 +104,21 @@ function rescheduleAppointment($appointmentId, $appointmentTimeId) {
 	} catch (Exception $e) {
 		$response['success'] = false;
 		$response['error'] = 'There was an error rescheduling the appointment on the server. Please refresh the page and try again.';
+	}
+
+	echo json_encode($response);
+}
+
+function cancelAppointment($appointmentId) {
+	$response = array();
+	$response['success'] = true;
+
+	try {
+		$appointmentAccessor = new AppointmentAccessor();
+		$appointmentAccessor->cancelAppointment($appointmentId);
+	} catch (Exception $e) {
+		$response['success'] = false;
+		$response['error'] = 'There was an error cancelling the appointment on the server. Please refresh the page and try again.';
 	}
 
 	echo json_encode($response);


### PR DESCRIPTION
**DO NOT MERGE UNTIL #224 IS MERGED, THIS PR BUILDS OFF OF THAT ONE BECAUSE I NEEDED THE INFORMATION**

This PR enables a volunteer to cancel an appointment from the appointment management page. 

I pulled out the cancel appointment logic into a new server/accessors/appointmentAccessor.class.php class. Idk if accessor is the right word, or if doing this the class way is even the way to go. But I do want to share that code so that we don't have to duplicate it. Let me know if you have thoughts / other opinions on it.

**TESTING**
* Log in
* Go to appointment management page
* Click on an appointment that is in status "Not Started"
  * At the bottom, near the reschedule button, there should be a Cancel Appointment button
  * Click the button
  * It should be successful
    * The status text should now be "Cancelled"
    * The status text should now be red
    * The Cancel Appointment button should be gone
* Click on an appointment that is any status but "Not Started"
  * The Cancel Appointment button should not be there