### PR TITLE
Add in a watch command for css/js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,17 @@
   "main": "index.js",
   "scripts": {
     "clean-start": "rm -rf ./dist/",
-    "transpile-js": "babel . -d ./dist --ignore ./node_modules/,./dist/",
-    "process-css:dev": "postcss ./**/*.css -d ./dist/ -b ./ --use postcss-cssnext",
-    "process-css:prod": "postcss ./**/*.css -d ./dist/ -b ./ --use postcss-cssnext cssnano",
+    "transpile-js": "babel . -d ./dist/ --ignore ./node_modules/,./dist/",
+    "process-css:dev": "postcss \"./!(dist|node_modules)/**/*.css\" -d ./dist/ -b ./ --use postcss-cssnext",
+    "process-css:prod": "postcss \"./!(dist|node_modules)/**/*.css\" -d ./dist/ -b ./ --use postcss-cssnext cssnano",
     "minify-js:prod": "run-for-every-file --src \"./dist/\" --dest \"./dist/\" --file \"**/*.js\" --not-file \"**/*/\" --run \"uglifyjs {{src-file}} -o {{dest-file}} --compress drop_console --mangle --keep-fnames\"",
     "cache-bust:prod": "hashmark ./dist/**/*.{js,css} {dir}/{name}-{hash}{ext} | sed 's/\\\\\\\\\\\\\\\\/\\//g' > replace-map.json && cat replace-map.json | replaceinfiles -s ./**/*.php -d {dir}/{name}{ext} && cat replace-map.json | sed s/\\.js/\\\\\\x22/g | replaceinfiles -s ./dist/**/*.js -d {dir}/{name}{ext} && rm replace-map.json",
     "clean-end": "rm -rf ./dist/node_modules",
     "build:dev": "npm run clean-start && npm run transpile-js && npm run process-css:dev && npm run clean-end",
-    "build:prod": "npm run clean-start && npm run transpile-js && npm run minify-js:prod && npm run process-css:prod && npm run cache-bust:prod && npm run clean-end"
+    "build:prod": "npm run clean-start && npm run transpile-js && npm run minify-js:prod && npm run process-css:prod && npm run cache-bust:prod && npm run clean-end",
+    "watch-js": "npm run transpile-js -- --watch",
+    "watch-css": "npm run process-css:dev -- --watch",
+    "watch": "npm-run-all --parallel watch-js watch-css"
   },
   "repository": {
     "type": "git",
@@ -31,6 +34,7 @@
     "babel-preset-env": "^1.6.1",
     "cssnano": "^3.10.0",
     "hashmark": "^5.0.0",
+    "npm-run-all": "^4.1.3",
     "postcss-cli": "^4.1.1",
     "postcss-cssnext": "^3.0.2",
     "run-for-every-file": "^1.1.0",


### PR DESCRIPTION
Should've done this a long time ago... especially considering the tools we were using already had this functionality built in! 

Anyway, here is an npm script to watch for changes in js/css files and run the `transpile-js` and `process-css:dev` scripts respectively.

**TESTING**
1. You will probably need to run `npm i` to install that npm-run-all dependency I added
2. Run `npm run watch`
3. Change a css file, observe as it re-processes that file for you 
4. Change a js file, observe as it re-transpiles that file for you
5. Rejoice cuz this will really speed things up, rather than running that `./scripts/build.sh` file all the time. I'm sorry I had y'all do that for so long.