### PR TITLE
Mark Appointments as Walk-Ins

### DIFF
--- a/queue/private.php
+++ b/queue/private.php
@@ -39,13 +39,13 @@
 			</thead>
 			<tbody>
 				<tr class="pointer"
-					ng-repeat="appointment in appointments | orderBy:['noshow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime'] | searchFor: clientSearch"
+					ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime'] | searchFor: clientSearch"
 					ng-if="appointment.completed == null"
 					ng-click="selectClient(appointment)">
 					<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 					<td class="queue-status" data-header="Progress">
-						<span class="pill pill-noshow" ng-if="appointment.noshow">No-show</span>
-						<span ng-if="!appointment.noshow">
+						<span class="pill pill-noshow" ng-if="appointment.noShow">No-show</span>
+						<span ng-if="!appointment.noShow">
 							<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 							<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 							<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>
@@ -77,8 +77,8 @@
 		<div class="client-information">
 			<h2 class="client-name">{{client.firstName}} {{client.lastName}}</h2>
 			<div>
-				<span class="pill pill-noshow" ng-if="client.noshow">No-show</span>
-				<span ng-if="!client.noshow">
+				<span class="pill pill-noshow" ng-if="client.noShow">No-show</span>
+				<span ng-if="!client.noShow">
 					<span class="pill" ng-class="client.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="client.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 					<span class="pill" ng-class="client.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>

--- a/queue/private.php
+++ b/queue/private.php
@@ -39,14 +39,14 @@
 			</thead>
 			<tbody>
 				<tr class="pointer"
-					ng-repeat="appointment in appointments | orderBy:['noShow', 'walkIn', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime'] | searchFor: clientSearch"
+					ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn'] | searchFor: clientSearch"
 					ng-if="appointment.completed == null"
 					ng-click="selectClient(appointment)">
 					<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 					<td class="queue-status" data-header="Progress">
 						<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
 						<span ng-if="!appointment.noShow">
-							<span class="pill pill-walkIn" ng-if="appointment.walkIn">Walk-In</span>
+							<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
 							<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 							<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 							<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>
@@ -80,7 +80,7 @@
 			<div>
 				<span class="pill pill-no-show" ng-if="client.noShow">No-show</span>
 				<span ng-if="!client.noShow">
-					<span class="pill pill-walkIn" ng-if="appointment.walkIn">Walk-In</span>
+					<span class="pill pill-walk-in" ng-if="client.walkIn">Walk-In</span>
 					<span class="pill" ng-class="client.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="client.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 					<span class="pill" ng-class="client.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>

--- a/queue/private.php
+++ b/queue/private.php
@@ -39,13 +39,14 @@
 			</thead>
 			<tbody>
 				<tr class="pointer"
-					ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime'] | searchFor: clientSearch"
+					ng-repeat="appointment in appointments | orderBy:['noShow', 'walkIn', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime'] | searchFor: clientSearch"
 					ng-if="appointment.completed == null"
 					ng-click="selectClient(appointment)">
 					<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 					<td class="queue-status" data-header="Progress">
-						<span class="pill pill-noshow" ng-if="appointment.noShow">No-show</span>
+						<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
 						<span ng-if="!appointment.noShow">
+							<span class="pill pill-walkIn" ng-if="appointment.walkIn">Walk-In</span>
 							<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 							<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 							<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>
@@ -77,8 +78,9 @@
 		<div class="client-information">
 			<h2 class="client-name">{{client.firstName}} {{client.lastName}}</h2>
 			<div>
-				<span class="pill pill-noshow" ng-if="client.noShow">No-show</span>
+				<span class="pill pill-no-show" ng-if="client.noShow">No-show</span>
 				<span ng-if="!client.noShow">
+					<span class="pill pill-walkIn" ng-if="appointment.walkIn">Walk-In</span>
 					<span class="pill" ng-class="client.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="client.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 					<span class="pill" ng-class="client.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>

--- a/queue/public.php
+++ b/queue/public.php
@@ -20,12 +20,13 @@
 		</tr>
 	</thead>
 	<tbody>
-		<tr ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime']" 
+		<tr ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn']" 
 			ng-if="appointment.completed == null">
 			<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 			<td class="queue-progress" data-header="Progress">
 				<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
 				<span ng-if="!appointment.noShow">
+					<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
 					<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 					<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Appointment in Progress</span>

--- a/queue/public.php
+++ b/queue/public.php
@@ -24,7 +24,7 @@
 			ng-if="appointment.completed == null">
 			<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 			<td class="queue-progress" data-header="Progress">
-				<span class="pill pill-noshow" ng-if="appointment.noShow">No-show</span>
+				<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
 				<span ng-if="!appointment.noShow">
 					<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>

--- a/queue/public.php
+++ b/queue/public.php
@@ -20,12 +20,12 @@
 		</tr>
 	</thead>
 	<tbody>
-		<tr ng-repeat="appointment in appointments | orderBy:['noshow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime']" 
+		<tr ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime']" 
 			ng-if="appointment.completed == null">
 			<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 			<td class="queue-progress" data-header="Progress">
-				<span class="pill pill-noshow" ng-if="appointment.noshow">No-show</span>
-				<span ng-if="!appointment.noshow">
+				<span class="pill pill-noshow" ng-if="appointment.noShow">No-show</span>
+				<span ng-if="!appointment.noShow">
 					<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 					<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
 					<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Appointment in Progress</span>

--- a/queue/queue.css
+++ b/queue/queue.css
@@ -75,7 +75,7 @@
 	border: 1px solid grey;
 }
 
-.pill-noshow {
+.pill-no-show {
 	color: #fff;
 	background-color: #D00000;
 }

--- a/queue/queue.css
+++ b/queue/queue.css
@@ -80,6 +80,11 @@
 	background-color: #D00000;
 }
 
+.pill-walk-in {
+	color: #fff;
+	background-color: #38764C;
+}
+
 /* Center the datepicker calendar on mobile */
 @media (max-width: 767px) {
 	.md-datepicker-calendar-pane.md-pane-open {

--- a/queue/queueController.js
+++ b/queue/queueController.js
@@ -14,10 +14,10 @@ define('queueController', [], function() {
 				day = $scope.currentDay;
 			if (month < 10) month = "0" + month;
 
-			let isoFormattedDate = year + "-" + month + "-" + day;
+			const isoFormattedDate = year + "-" + month + "-" + day;
 
 			if ($scope.selectedSite == null || $scope.selectedSite.siteId == null) return;
-			let siteId = $scope.selectedSite.siteId;
+			const siteId = $scope.selectedSite.siteId;
 			
 			QueueDataService.getAppointments(isoFormattedDate, siteId).then(function(data) {
 				if(data == null) {
@@ -30,6 +30,7 @@ define('queueController', [], function() {
 						appointment.ended = appointment.timeAppointmentEnded != null;
 						appointment.name = appointment.firstName + " " + appointment.lastName;
 						appointment.noShow = appointment.noShow == true; // Do this since the SQL returns 0/1 for false/true, and we want it to be true/false instead of 0/1
+						appointment.walkIn = appointment.walkIn == true; // ^ Similarly here.
 						return appointment;
 					});
 				} else {

--- a/queue/queueController.js
+++ b/queue/queueController.js
@@ -29,7 +29,7 @@ define('queueController', [], function() {
 						appointment.preparing = appointment.timeAppointmentStarted != null;
 						appointment.ended = appointment.timeAppointmentEnded != null;
 						appointment.name = appointment.firstName + " " + appointment.lastName;
-						appointment.noshow = appointment.noshow == true; // Do this since the SQL returns 0/1 for false/true, and we want it to be true/false instead of 0/1
+						appointment.noShow = appointment.noShow == true; // Do this since the SQL returns 0/1 for false/true, and we want it to be true/false instead of 0/1
 						return appointment;
 					});
 				} else {

--- a/queue/queuePrivateController.js
+++ b/queue/queuePrivateController.js
@@ -19,13 +19,13 @@ define('queuePrivateController', [], function() {
 		}
 	
 		$scope.checkIn = function() {
-			const noshow = $scope.client.noshow;
+			const noShow = $scope.client.noShow;
 			$scope.client.checkedIn = true;
-			$scope.client.noshow = false;
+			$scope.client.noShow = false;
 			QueueDataService.checkInNow(new Date().toISOString(), $scope.client.appointmentId).then(function(result) {
 				if(!result.success) {
 					$scope.client.checkedIn = false;
-					$scope.client.noshow = noshow;
+					$scope.client.noShow = noShow;
 					alert(result.error);
 				}
 			});

--- a/queue/queuePrivateController.js
+++ b/queue/queuePrivateController.js
@@ -4,10 +4,6 @@ define('queuePrivateController', [], function() {
 		angular.extend(this, $controller('queueController', {$scope: $scope}));
 	
 		$scope.appointmentNotesAreaSharedProperties = AppointmentNotesAreaSharedPropertiesService.getSharedProperties();
-
-		function fixedEncodeURIComponent (str) {
-			return encodeURIComponent(str).replace(/[!'()]/g, escape).replace(/\*/g, "%2A");
-		}
 	
 		$scope.selectClient = function(client) {
 			$scope.client = client;

--- a/server/queue/queue.php
+++ b/server/queue/queue.php
@@ -16,7 +16,7 @@ function loadPublicQueue($data) {
 	$query = "SELECT Appointment.appointmentId, TIME_FORMAT(scheduledTime, '%l:%i %p') AS scheduledTime, firstName, lastName, 
 				timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, completed,
 				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
-				(Appointment.scheduledTime < Appointment.createdAt) AS walkIn
+				(AppointmentTime.scheduledTime < Appointment.createdAt) AS walkIn
 			FROM Appointment
 				LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
 				JOIN Client ON Appointment.clientId = Client.clientId
@@ -46,7 +46,7 @@ function loadPrivateQueue($data) {
 				firstName, lastName, timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, 
 				completed, language, Client.clientId, 
 				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
-				(Appointment.scheduledTime < Appointment.createdAt) AS walkIn ";
+				(AppointmentTime.scheduledTime < Appointment.createdAt) AS walkIn ";
 	if ($canViewClientInformation) {
 		$query .= ", phoneNumber, emailAddress ";
 	}

--- a/server/queue/queue.php
+++ b/server/queue/queue.php
@@ -15,11 +15,12 @@ function loadPublicQueue($data) {
 	GLOBAL $DB_CONN;
 	$query = "SELECT Appointment.appointmentId, TIME_FORMAT(scheduledTime, '%l:%i %p') AS scheduledTime, firstName, lastName, 
 				timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, completed,
-				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noshow 
+				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
+				(Appointment.scheduledTime < Appointment.createdAt) AS walkIn
 			FROM Appointment
-			LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
-			JOIN Client ON Appointment.clientId = Client.clientId
-			JOIN AppointmentTime ON Appointment.appointmentTimeId = AppointmentTime.appointmentTimeId
+				LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
+				JOIN Client ON Appointment.clientId = Client.clientId
+				JOIN AppointmentTime ON Appointment.appointmentTimeId = AppointmentTime.appointmentTimeId
 			WHERE DATE(AppointmentTime.scheduledTime) = ?
 				AND AppointmentTime.siteId = ?
 				AND Appointment.archived = FALSE
@@ -44,14 +45,15 @@ function loadPrivateQueue($data) {
 	$query = "SELECT Appointment.appointmentId, TIME_FORMAT(AppointmentTime.scheduledTime, '%l:%i %p') AS scheduledTime, 
 				firstName, lastName, timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, 
 				completed, language, Client.clientId, 
-				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noshow ";
+				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
+				(Appointment.scheduledTime < Appointment.createdAt) AS walkIn ";
 	if ($canViewClientInformation) {
 		$query .= ", phoneNumber, emailAddress ";
 	}
 	$query .= "FROM Appointment
-			LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
-			JOIN Client ON Appointment.clientId = Client.clientId
-			JOIN AppointmentTime ON Appointment.appointmentTimeId = AppointmentTime.appointmentTimeId
+				LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
+				JOIN Client ON Appointment.clientId = Client.clientId
+				JOIN AppointmentTime ON Appointment.appointmentTimeId = AppointmentTime.appointmentTimeId
 			WHERE DATE(AppointmentTime.scheduledTime) = ?
 				AND AppointmentTime.siteId = ?
 				AND Appointment.archived = FALSE


### PR DESCRIPTION
This PR adds a "Walk-In" pill to the queue when an appointment is a walk-in. The way we determine if an appointment is a walk-in is if the createdAt time is > scheduledTime.

**TESTING**
1. Update an Appointment to have a createdAt time greater than it's scheduledTime. You can use the following query to identify appointments, their scheduled time, and their site title for the "Test Site" site.
```
USE vita;
SELECT a.appointmentId, at.scheduledTime, s.title
    FROM Appointment a
    JOIN AppointmentTime at ON a.appointmentTimeId = at.appointmentTimeId
    JOIN Site s ON at.siteId = s.siteId
    WHERE s.siteId = 1
    ORDER BY scheduledTime;
```
The following query can be used to update an appointment then to make it a walk-in appointment:
```
USE vita;
UPDATE Appointment
    SET createdAt = 'SOME_TIME_PAST_THE_SCHEDULED_TIME'
    WHERE appointmentId = INSERT_APPOINTMENT_ID_HERE
```
2. Navigate to the public queue and select the "Test Site" and proper date
3. The appointment you changed should now have a green "Walk-In" pill next to it now, and it should be the very last appointment shown for the scheduledTime
4. Log in as preparer
5. Navigate to the private queue and select the "Test Site" and proper date
6. The appointment you changed should now have a green "Walk-In" pill next to it now, and it should be the very last appointment shown for the scheduledTime
7. Check in any appointment and the appointment that is a Walk-In
8. The Walk-In appointment should be the last one displayed for the Checked-In + ScheduledTime pair