### PR TITLE
Remove downloadFile function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+function downloadSiteSchedule() {
+	const fileUrl = "/server/download/downloadSchedule.php";
+	let iframe = document.getElementById("hiddenDownloader");
+	if (iframe == null) {
+		iframe = document.createElement('iframe');
+		iframe.id = "hiddenDownloader";
+		iframe.style.visibility = 'hidden';
+		document.body.appendChild(iframe);
+	}
+
+	iframe.src = fileUrl;
+}

--- a/index.php
+++ b/index.php
@@ -131,7 +131,7 @@ function wdnInclude($path)
 									<a class="wdn-button wdn-button-brand" href="/signup">Make an Appointment</a>
 								</div>
 								<div class="bp768-wdn-col-one-half visual-island">
-									<a class="wdn-button wdn-button-brand" href="/server/download/downloadSchedule.php">Download Site Schedule</a>
+									<button class="wdn-button wdn-button-brand" onClick="javascript:downloadSiteSchedule()">Download Site Schedule</button>
 								</div>
 							</div>
 						</div>
@@ -186,5 +186,6 @@ function wdnInclude($path)
 	</div>
 	<?php wdnInclude("/wdn/templates_4.1/includes/body_scripts.html"); ?>
 	<?php require_once "$root/server/global_includes.php"; ?>
+	<script src="/dist/index.js"></script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -131,7 +131,7 @@ function wdnInclude($path)
 									<a class="wdn-button wdn-button-brand" href="/signup">Make an Appointment</a>
 								</div>
 								<div class="bp768-wdn-col-one-half visual-island">
-									<a class="wdn-button wdn-button-brand" href="/server/download/downloadFile.php?file=2018_Schedule.pdf">Download Site Schedule</a>
+									<a class="wdn-button wdn-button-brand" href="/server/download/downloadSchedule.php">Download Site Schedule</a>
 								</div>
 							</div>
 						</div>

--- a/server/download/downloadSchedule.php
+++ b/server/download/downloadSchedule.php
@@ -1,8 +1,8 @@
 <?php
 
-downloadFile($_REQUEST['file']);
+downloadFile('2018_Schedule.pdf');
 
-function downloadFile($fileName) {	
+function downloadFile($fileName) {
 	$root = realpath($_SERVER['DOCUMENT_ROOT']);
 	$filePath = "$root/server/download/documents/$fileName";
 	


### PR DESCRIPTION
Removing downloadFile in favor of a file that can only get the site schedule. 

**TESTING**
* Run `npm run watch` to compile files
* Just make sure the "Download Site Schedule" button still functions correctly