### PR TITLE
Notifications in Appointment Signup rather than alert

### DIFF
--- a/signup/signup.js
+++ b/signup/signup.js
@@ -9,7 +9,8 @@ require.config({
 		appointmentPickerSharedPropertiesService: '/dist/components/appointmentPicker/appointmentPickerSharedPropertiesService',
 		appointmentPickerDataService: '/dist/components/appointmentPicker/appointmentPickerDataService',
 		appointmentPickerController: '/dist/components/appointmentPicker/appointmentPickerController',
-		'bootstrap-ui': '/dist/assets/js/bootstrap/ui-bootstrap-buttons-2.5.0.min'
+		'bootstrap-ui': '/dist/assets/js/bootstrap/ui-bootstrap-buttons-2.5.0.min',
+		notificationUtilities: '/dist/assets/js/utilities/notificationUtilities'
 	},
 	shim: {
 		'ngAnimate': ['angular'],
@@ -31,14 +32,16 @@ require(['angular', 'ngAnimate', 'ngAria', 'ngTouch', 'bootstrap-ui'], function(
 		'signupController',
 		'appointmentPickerSharedPropertiesService',
 		'appointmentPickerDataService',
-		'appointmentPickerController'
+		'appointmentPickerController',
+		'notificationUtilities'
 	],
 	function (
 		SignupDataService,
 		SignupController, 
 		AppointmentPickerSharedPropertiesService,
 		AppointmentPickerDataService,
-		AppointmentPickerController
+		AppointmentPickerController,
+		NotificationUtilities
 	) {
 		'use strict';
 
@@ -66,6 +69,9 @@ require(['angular', 'ngAnimate', 'ngAria', 'ngTouch', 'bootstrap-ui'], function(
 				templateUrl: '/components/appointmentPicker/appointmentPicker.php'
 			};
 		});
+
+		// Notification utilities
+		signupApp.factory('notificationUtilities', NotificationUtilities);
 
 		angular.bootstrap(document.getElementById('signupApp'), ['signupApp']);
 

--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -1,6 +1,6 @@
 define('signupController', [], function() {
 
-	function signupController($scope, $sce, SignupService, sharedPropertiesService) {
+	function signupController($scope, $sce, SignupService, sharedPropertiesService, NotificationUtilities) {
 		
 		$scope.sharedProperties = sharedPropertiesService.getSharedProperties();
 		$scope.successMessage = null;
@@ -43,8 +43,9 @@ define('signupController', [], function() {
 					document.body.scrollTop = document.documentElement.scrollTop = 0;
 					$scope.appointmentId = response.appointmentId;
 					$scope.successMessage = $sce.trustAsHtml(response.message);
-				}else{
-					alert('There was an error on the server! Please refresh the page in a few minutes and try again.');
+					NotificationUtilities.giveNotice('Success', 'You have successfully scheduled an appointment!');
+				} else {
+					NotificationUtilities.giveNotice('Failure', 'There was an error on the server! Please refresh the page in a few minutes and try again.', false);
 				}
 			});
 		}
@@ -61,13 +62,14 @@ define('signupController', [], function() {
 				if(typeof response !== 'undefined' && response){
 					if (response.success) {
 						$scope.emailButton.text = "Sent!";
+						NotificationUtilities.giveNotice('Success', 'The email has been sent!');
 					} else {
-						alert(response.error);
 						$scope.emailButton.disabled = false;
+						NotificationUtilities.giveNotice('Failure', response.error, false);
 					}
 				}else{
-					alert('There was an error on the server! Try again or please print this page instead.');
 					$scope.emailButton.disabled = false;
+					NotificationUtilities.giveNotice('Failure', 'There was an error on the server! Try again or please print this page instead.', false);
 				}
 			});
 		}
@@ -95,7 +97,7 @@ define('signupController', [], function() {
 
 	}
 
-	signupController.$inject = ['$scope', '$sce', 'signupDataService', 'appointmentPickerSharedPropertiesService'];
+	signupController.$inject = ['$scope', '$sce', 'signupDataService', 'appointmentPickerSharedPropertiesService', 'notificationUtilities'];
 
 	return signupController;
 


### PR DESCRIPTION
Updated the `signup.js` to use `NotificationUtilities` rather than javascript `alert`s. 

## Testing
1. Run the `./scripts/build.sh`
2. Run the database scripts
3. You'll have to update `signup/signup.php` to remove the commented out code that is preventing you from signing up for an appointment
4. Go sign up for an appointment
5. You should get a green success notification
6. Hit the send email button, you should get a green success notification