### PR TITLE
Update percentageAppointment maximum to 300 in FE and BE

### DIFF
--- a/management/sites/sites.php
+++ b/management/sites/sites.php
@@ -172,7 +172,7 @@
 									</th>
 									<th id="appointmentTimePercentageAppointmentsHeader">
 										Percentage Appts
-										<a class="tooltip pointer" title="This specifies the percentage of the preparers that are allotted for scheduled (as opposed to walk-in) appointments. That is: number of appointments allowed to be scheduled online = number of preparers * percentage appointments. Default is 100%.">
+										<a class="tooltip pointer" title="This specifies the percentage of the preparers that are allotted for scheduled (as opposed to walk-in) appointments. That is: number of appointments allowed to be scheduled online = number of preparers * percentage appointments. Default is 100%, max is 300%.">
 											<span class="wdn-icon-info" aria-hidden="true"></span>
 										</a>
 									</th>
@@ -282,7 +282,7 @@
 									name="percentageAppointments"
 									ng-model="addAppointmentTimeInformation.percentageAppointments"
 									min="0"
-									max="100"
+									max="300"
 									required />
 								<div ng-show="form.$submitted || form.percentageAppointments.$touched">
 									<label class="error" ng-show="form.percentageAppointments.$error.required">This field is required.</label>

--- a/server/management/sites/sites.php
+++ b/server/management/sites/sites.php
@@ -186,7 +186,7 @@ function addAppointmentTime($siteId, $dateString, $scheduledTimeString, $minimum
 		}
 
 		if (!isset($percentageAppointments)) throw new Exception('Invalid percent appointments given', MY_EXCEPTION);
-		if (isset($percentageAppointments) && ((int)$percentageAppointments < 0 || (int)$percentageAppointments > 100)) throw new Exception('Invalid percent appointments given', MY_EXCEPTION);
+		if (isset($percentageAppointments) && ((int)$percentageAppointments < 0 || (int)$percentageAppointments > 300)) throw new Exception('Invalid percent appointments given', MY_EXCEPTION);
 
 		if (!isset($approximateLengthInMinutes)) throw new Exception('Invalid approximate length in minutes given', MY_EXCEPTION);
 		if (isset($approximateLengthInMinutes) && ((int)$approximateLengthInMinutes < 0)) throw new Exception('Invalid approximate length in minutes given', MY_EXCEPTION);


### PR DESCRIPTION
Per this [conversation](https://github.com/UNL-CSE-AMBASSADORS/VITA/pull/265#discussion_r244627219), updating the `percentageAppointment` maximum from 100 to 300 on both the front-end and the back-end. The check constraint was changed in DB script and added to PROD DB in PR #265. 