### PR TITLE
Show More Appointment Statuses on Queue

### DIFF
--- a/queue/private.php
+++ b/queue/private.php
@@ -39,18 +39,22 @@
 			</thead>
 			<tbody>
 				<tr class="pointer"
-					ng-repeat="appointment in appointments | orderBy:['noShow', 'cancelled', 'ended', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn'] | searchFor: clientSearch"
+					ng-repeat="appointment in appointments | orderBy:['noShow', 'cancelled', 'completed == false', 'ended', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn'] | searchFor: clientSearch"
 					ng-click="selectClient(appointment)">
 					<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 					<td class="queue-status" data-header="Progress">
-						<span class="pill pill-red" ng-if="appointment.noShow">No-show</span>
 						<span class="pill pill-red" ng-if="appointment.cancelled">Cancelled</span>
-						<span ng-if="!appointment.noShow && !appointment.cancelled">
-							<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
-							<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
-							<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
-							<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>
-							<span class="pill" ng-class="appointment.ended ? 'pill-complete': 'pill-incomplete'">Appointment Complete</span>
+						<span class="pill pill-red" ng-if="appointment.noShow && !appointment.cancelled">No-show</span>
+						<span class="pill pill-red" ng-if="appointment.completed == false && !appointment.cancelled">Incomplete</span>
+						<span ng-if="!appointment.noShow && !appointment.cancelled && appointment.completed != false">
+							<span class="pill pill-green" ng-if="appointment.ended">Completed</span>
+							<span ng-if="!appointment.ended">
+								<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
+								<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
+								<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>
+								<span class="pill" ng-class="appointment.preparing ? 'pill-complete': 'pill-incomplete'">Preparing</span>
+								<span class="pill" ng-class="appointment.ended ? 'pill-complete': 'pill-incomplete'">Appointment Complete</span>
+							</span>
 						</span>
 					</td>
 					<td class="queue-time" data-header="Scheduled Time">{{appointment.scheduledTime}}</td>

--- a/queue/private.php
+++ b/queue/private.php
@@ -39,13 +39,13 @@
 			</thead>
 			<tbody>
 				<tr class="pointer"
-					ng-repeat="appointment in appointments | orderBy:['noShow', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn'] | searchFor: clientSearch"
-					ng-if="appointment.completed == null"
+					ng-repeat="appointment in appointments | orderBy:['noShow', 'cancelled', 'ended', 'timeIn == null', 'timeReturnedPapers == null', 'timeAppointmentStarted == null', 'scheduledTime', 'walkIn'] | searchFor: clientSearch"
 					ng-click="selectClient(appointment)">
 					<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 					<td class="queue-status" data-header="Progress">
-						<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
-						<span ng-if="!appointment.noShow">
+						<span class="pill pill-red" ng-if="appointment.noShow">No-show</span>
+						<span class="pill pill-red" ng-if="appointment.cancelled">Cancelled</span>
+						<span ng-if="!appointment.noShow && !appointment.cancelled">
 							<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
 							<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>
 							<span class="pill" ng-class="appointment.paperworkComplete ? 'pill-complete': 'pill-incomplete'">Completed Paperwork</span>

--- a/queue/private.php
+++ b/queue/private.php
@@ -34,7 +34,6 @@
 					<th class="queue-name">Name</th>
 					<th class="queue-progress">Progress</th>
 					<th class="queue-time">Scheduled Time</th>
-					<th class="queue-id">Appointment ID</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -58,7 +57,6 @@
 						</span>
 					</td>
 					<td class="queue-time" data-header="Scheduled Time">{{appointment.scheduledTime}}</td>
-					<td class="queue-id" data-header="Appointment ID">#{{appointment.appointmentId}}</td>
 				</tr>
 			</tbody>
 		</table>
@@ -177,7 +175,7 @@
 			</form>
 		</div>
 
-		<div class="client-appointmentId dcf-txt-xs dcf-txt-right"><b>Appointment ID: </b>{{client.appointmentId}}</div>
+		<div class="client-appointmentId dcf-txt-xs dcf-txt-right dcf-mb-3"><b>Appointment ID: </b>{{client.appointmentId}}</div>
 	</div>
 </div>
 <!-- End of Client/Appointment Info Section -->

--- a/queue/public.php
+++ b/queue/public.php
@@ -24,7 +24,7 @@
 			ng-if="appointment.completed == null">
 			<th class="queue-name" data-header="Name">{{appointment.firstName}} {{appointment.lastName}}</th>
 			<td class="queue-progress" data-header="Progress">
-				<span class="pill pill-no-show" ng-if="appointment.noShow">No-show</span>
+				<span class="pill pill-red" ng-if="appointment.noShow">No-show</span>
 				<span ng-if="!appointment.noShow">
 					<span class="pill pill-walk-in" ng-if="appointment.walkIn">Walk-In</span>
 					<span class="pill" ng-class="appointment.checkedIn ? 'pill-complete': 'pill-incomplete'">Checked In</span>

--- a/queue/queue.css
+++ b/queue/queue.css
@@ -81,6 +81,11 @@
 	background-color: #D00000;
 }
 
+.pill-green {
+	color: #fff;
+	background-color: #38764C;
+}
+
 .pill-walk-in {
 	color: #fff;
 	background-color: #38764C;

--- a/queue/queue.css
+++ b/queue/queue.css
@@ -76,7 +76,7 @@
 	border: 1px solid grey;
 }
 
-.pill-no-show {
+.pill-red {
 	color: #fff;
 	background-color: #D00000;
 }

--- a/queue/queueController.js
+++ b/queue/queueController.js
@@ -31,6 +31,7 @@ define('queueController', [], function() {
 						appointment.name = appointment.firstName + " " + appointment.lastName;
 						appointment.noShow = appointment.noShow == true; // Do this since the SQL returns 0/1 for false/true, and we want it to be true/false instead of 0/1
 						appointment.walkIn = appointment.walkIn == true; // ^ Similarly here.
+						appointment.cancelled = appointment.cancelled == true; // ^ Similarly here.
 						return appointment;
 					});
 				} else {

--- a/server/queue/queue.php
+++ b/server/queue/queue.php
@@ -14,7 +14,7 @@ if ($USER->isLoggedIn()) {
 function loadPublicQueue($data) {
 	GLOBAL $DB_CONN;
 	$query = "SELECT Appointment.appointmentId, TIME_FORMAT(scheduledTime, '%l:%i %p') AS scheduledTime, firstName, lastName, 
-				timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, completed,
+				timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, completed, cancelled,
 				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
 				(AppointmentTime.scheduledTime < Appointment.createdAt) AS walkIn
 			FROM Appointment
@@ -44,7 +44,7 @@ function loadPrivateQueue($data) {
 
 	$query = "SELECT Appointment.appointmentId, TIME_FORMAT(AppointmentTime.scheduledTime, '%l:%i %p') AS scheduledTime, 
 				firstName, lastName, timeIn, timeReturnedPapers, timeAppointmentStarted, timeAppointmentEnded, 
-				completed, language, Client.clientId, 
+				completed, cancelled, language, Client.clientId, 
 				(DATE_ADD(AppointmentTime.scheduledTime, INTERVAL 15 MINUTE) < NOW() AND timeIn IS NULL) AS noShow,
 				(AppointmentTime.scheduledTime < Appointment.createdAt) AS walkIn ";
 	if ($canViewClientInformation) {


### PR DESCRIPTION
This was an issue that sometimes a volunteer would make a mistake and would need to add a note on an appointment on the queue, but they couldn't because the appointment disappeared, so they then had to go to the appointment management page.

This PR makes it so that cancelled, incomplete, and complete appointments appear on the private queue still.

![image](https://user-images.githubusercontent.com/9295744/72223642-b89ca080-3536-11ea-8929-178fd87a77ae.png)


Also just removed the appointment ID from the private queue table as it wasn't really necessary.