### PR TITLE
Automatically Send Confirmation Email

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -3,9 +3,11 @@
 }
 
 label.form-required::after {
-	content: " *";
+	content: " required";
 	color: #d00000;
-	font-size: 1.247rem;
+	font-style: italic;
+	font-size: 0.75rem;
+	vertical-align: super;
 }
 
 [data-toggle=buttons]>.dcf-btn-group>.dcf-btn input[type=checkbox],

--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -40,9 +40,7 @@ function storeAppointment($data){
 		$response['message'] = AppointmentConfirmationUtilities::generateAppointmentConfirmation($appointmentId);
 	} catch (Exception $e) {
 		$DB_CONN->rollback();
-		
-		// TODO
-		// mail('vita@cse.unl.edu', 'Please help, everything is on fire?', print_r($e, true).print_r($data, true));
+		$response['message'] = 'An error occurred while trying to confirm the appointment. Please try again in a few minutes.';
 	}
 
 	print json_encode($response);

--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -114,8 +114,8 @@ function emailConfirmation($data) {
 	$response['success'] = false;
 
 	try {
-		if (!isset($data['email']) || !preg_match('/.+@.+/', $data['email'])) throw new Exception('Invalid email address given. Unable to send email.', MY_EXCEPTION);
-		if (!isset($data['appointmentId'])) throw new Exception('Invalid information received. Unable to send email.', MY_EXCEPTION); 
+		if (!isset($data['email']) || !preg_match('/.+@.+/', $data['email'])) throw new Exception('Unable to send email--An invalid email address was given.', MY_EXCEPTION);
+		if (!isset($data['appointmentId'])) throw new Exception('Unable to send email--invalid information was received.', MY_EXCEPTION); 
 
 		$confirmationMessage = AppointmentConfirmationUtilities::generateAppointmentConfirmation($data['appointmentId']);
 		
@@ -129,7 +129,7 @@ function emailConfirmation($data) {
 		if ($e->getCode() === MY_EXCEPTION) {
 			$response['error'] = $e->getMessage();
 		} else {
-			$response['error'] = 'There was an error on the server, please try again. If the problem persists, please print this page instead.';
+			$response['error'] = 'There was an error on the server sending the confirmation email, please try again. If the problem persists, please print this page instead.';
 		}
 	}
 

--- a/server/storeAppointment.php
+++ b/server/storeAppointment.php
@@ -114,8 +114,8 @@ function emailConfirmation($data) {
 	$response['success'] = false;
 
 	try {
-		if (!isset($data['email']) || !preg_match('/.+@.+/', $data['email'])) throw new Exception('Unable to send email--An invalid email address was given.', MY_EXCEPTION);
-		if (!isset($data['appointmentId'])) throw new Exception('Unable to send email--invalid information was received.', MY_EXCEPTION); 
+		if (!isset($data['email']) || !preg_match('/.+@.+/', $data['email'])) throw new Exception('Unable to send confirmation email--An invalid email address was given.', MY_EXCEPTION);
+		if (!isset($data['appointmentId'])) throw new Exception('Unable to send confirmation email--Invalid information was received.', MY_EXCEPTION); 
 
 		$confirmationMessage = AppointmentConfirmationUtilities::generateAppointmentConfirmation($data['appointmentId']);
 		

--- a/signup/signup.php
+++ b/signup/signup.php
@@ -43,6 +43,7 @@
 				<li class="form-textfield">
 					<label class="dcf-label form-label" for="email">Email</label>
 					<input type="email" class="dcf-input-text form-control" name="email" id="email" ng-model="data.email">
+					<p class="dcf-txt-xs">A confirmation email will be sent to this email address.</p>
 				</li>
 
 				<li class="form-textfield">
@@ -299,11 +300,6 @@
 	<ng-bind-html ng-bind-html="successMessage"></ng-bind-html>
 
 	<div id="successfulSignupButtons" class="dcf-mt-4">
-		<button type="button" class="dcf-btn dcf-btn-primary" onclick="window.print();">Print</button>
-		<button type="button" 
-			class="dcf-btn dcf-btn-primary email-confirmation-button" 
-			ng-if="data.email != null && data.email.length > 0"
-			ng-disabled="emailButton.disabled"
-			ng-click="emailConfirmation()">{{emailButton.text}}</button>
+		<button type="button" class="dcf-btn dcf-btn-primary" onclick="window.print();">Print this Confirmation</button>
 	</div>
 </div>

--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -7,9 +7,6 @@ define('signupController', [], function() {
 		$scope.appointmentId = null; // The id of the client's appointment once they successfully sign up
 		$scope.data = {};
 		$scope.questions = [];
-		$scope.emailButton = {};
-		$scope.emailButton.disabled = false
-		$scope.emailButton.text = 'Email Me this Confirmation';
 
 		$scope.countries = [ 
 			{ 'name': 'China', 'treatyType': 'china' },
@@ -110,6 +107,11 @@ define('signupController', [], function() {
 					$scope.appointmentId = response.appointmentId;
 					$scope.successMessage = $sce.trustAsHtml(response.message);
 					NotificationUtilities.giveNotice('Success', 'You have successfully scheduled an appointment!');
+
+					// Send the confirmation email
+					if ($scope.data.email != null && $scope.data.email.length > 0) {
+						$scope.emailConfirmation();
+					}
 				} else {
 					NotificationUtilities.giveNotice('Failure', 'There was an error on the server! Please refresh the page in a few minutes and try again.', false);
 				}
@@ -117,7 +119,6 @@ define('signupController', [], function() {
 		};
 
 		$scope.emailConfirmation = function() {
-			$scope.emailButton.disabled = true;
 			const data = {
 				"action": "emailConfirmation",
 				"appointmentId": $scope.appointmentId,
@@ -127,15 +128,12 @@ define('signupController', [], function() {
 			SignupService.emailConfirmation(data).then(function(response) {
 				if (typeof response !== 'undefined' && response){
 					if (response.success) {
-						$scope.emailButton.text = "Sent!";
-						NotificationUtilities.giveNotice('Success', 'The email has been sent!');
+						NotificationUtilities.giveNotice('Success', 'A confirmation email has been sent!');
 					} else {
-						$scope.emailButton.disabled = false;
 						NotificationUtilities.giveNotice('Failure', response.error, false);
 					}
 				} else {
-					$scope.emailButton.disabled = false;
-					NotificationUtilities.giveNotice('Failure', 'There was an error on the server! Try again or please print this page instead.', false);
+					NotificationUtilities.giveNotice('Failure', 'There was an error sending a confirmation email! Please print this page instead.', false);
 				}
 			});
 		};


### PR DESCRIPTION
After signing up, a confirmation email is automatically sent to the client. This was a request that Katie mentioned that clients wanted--it also was a problem where a volunteer would sign someone up, but they wouldn't receive a confirmation email since the volunteer wouldn't hit the "Email me" button at the bottom. This addresses that issue.

I also made a small styling change to the `form.css` to have `required` after a required input rather than `*`. I saw this on the WDN website in their form, and wanted to move to be more in-line with that. I also think it looks a little nicer:
![image](https://user-images.githubusercontent.com/9295744/72224187-fe5c6780-353c-11ea-806e-e2ac3e2f339f.png)
