### PR TITLE
Quick Fix for Less Appointments for International Site

### DIFF
--- a/server/api/appointments/getTimes.php
+++ b/server/api/appointments/getTimes.php
@@ -125,16 +125,30 @@ function calculateRemainingAppointmentsAvailableForResidentialAppointment($appoi
 	return ceil($availableAppointmentSpots) - $appointmentCount;
 }
 
-function calculateRemainingAppointmentsAvailableForInternationalAppointment($treatyType, $numberAppointmentsAlreadyScheduled) {
-	if ($treatyType === 'china') {
-		return 15 - $numberAppointmentsAlreadyScheduled;
-	} else if ($treatyType === 'india') {
-		return 6 - $numberAppointmentsAlreadyScheduled;
-	} else if ($treatyType === 'treaty') {
-		return 5 - $numberAppointmentsAlreadyScheduled;
-	} else if ($treatyType === 'non-treaty') {
-		return 15 - $numberAppointmentsAlreadyScheduled;
-	} 
+function calculateRemainingAppointmentsAvailableForInternationalAppointment($treatyType, $numberAppointmentsAlreadyScheduled, $appointmentTimeId) {
+	// TODO: This is a real band-aid that we are using to enable less appointments for certain time slots
+	$appointmentTimeIdsForLessAppointments = array(968, 969, 970, 971, 972);
+	if (in_array($appointmentTimeId, $appointmentTimeIdsForLessAppointments)) {
+		if ($treatyType === 'china') {
+			return 7 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'india') {
+			return 3 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'treaty') {
+			return 2 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'non-treaty') {
+			return 7 - $numberAppointmentsAlreadyScheduled;
+		}
+	} else {
+		if ($treatyType === 'china') {
+			return 15 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'india') {
+			return 6 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'treaty') {
+			return 5 - $numberAppointmentsAlreadyScheduled;
+		} else if ($treatyType === 'non-treaty') {
+			return 15 - $numberAppointmentsAlreadyScheduled;
+		} 
+	}
 }
 
 class DateSiteTimeMap {
@@ -154,7 +168,7 @@ class DateSiteTimeMap {
 		if ($this->appointmentType === 'residential') {
 			$appointmentsAvailable = calculateRemainingAppointmentsAvailableForResidentialAppointment($dstObject['numberOfAppointmentsAlreadyMade'], $dstObject['percentageAppointments'], $dstObject['numberOfPreparers'], $dstObject['minimumNumberOfAppointments'], $dstObject['maximumNumberOfAppointments']);
 		} else {
-			$appointmentsAvailable = calculateRemainingAppointmentsAvailableForInternationalAppointment($this->appointmentType, $dstObject['numberOfAppointmentsAlreadyMade']);
+			$appointmentsAvailable = calculateRemainingAppointmentsAvailableForInternationalAppointment($this->appointmentType, $dstObject['numberOfAppointmentsAlreadyMade'], $dstObject['appointmentTimeId']);
 		}
 		
 


### PR DESCRIPTION
Katie wanted the last time slot at the international sites to have less appointments than the other times... Unfortunately, the international system hasn't really been built out enough to handle this situation. So this is a quick fix that directly targets those 5pm appointment times by ID and halves the number of available appointments.