### PR TITLE
Bump UNL Framework version to 5.1

### DIFF
--- a/appointment/reschedule/index.php
+++ b/appointment/reschedule/index.php
@@ -14,7 +14,7 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -25,7 +25,7 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Reschedule a VITA Appointment | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/assets/css/bootstrap.btn-group.min.css">
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
@@ -34,49 +34,49 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -118,14 +118,14 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/appointment/reschedule/selfServiceAppointmentReschedule.js"></script>

--- a/appointment/upload-documents/index.php
+++ b/appointment/upload-documents/index.php
@@ -14,7 +14,7 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -25,7 +25,7 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Upload Documents | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/assets/css/bootstrap.btn-group.min.css">
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
@@ -33,49 +33,49 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -117,14 +117,14 @@ if (isset($_REQUEST['token']) && strlen($_REQUEST['token']) === $EXPECTED_TOKEN_
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/appointment/upload-documents/uploadDocuments.js"></script>

--- a/error_pages/404.php
+++ b/error_pages/404.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Not Found | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/error_pages/error_page.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -115,14 +115,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->

--- a/error_pages/500.php
+++ b/error_pages/500.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Server Error | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/error_pages/error_page.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -115,14 +115,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/index.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -186,14 +186,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/index.js"></script>

--- a/index.template.5.php
+++ b/index.template.5.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<!-- Place optional header elements here -->
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -110,14 +110,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->

--- a/login/index.php
+++ b/login/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Login | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/login/login.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -170,14 +170,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/login/login.js"></script>

--- a/management/analytics/index.php
+++ b/management/analytics/index.php
@@ -16,7 +16,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -27,55 +27,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Analytics | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/management/analytics/analytics.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -118,14 +118,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/analytics/analytics.js"></script>

--- a/management/appointments/index.php
+++ b/management/appointments/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,56 +26,56 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Appointment Management | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
 	<link rel="stylesheet" href="/dist/management/appointments/appointments.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -118,14 +118,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/appointments/appointments.js"></script>

--- a/management/documents/index.php
+++ b/management/documents/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,55 +26,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Print Documents | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/management/documents/documents.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -138,14 +138,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/documents/documents.js"></script>

--- a/management/index.php
+++ b/management/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,55 +26,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Management | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<!-- Place optional header elements here -->
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -120,14 +120,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->

--- a/management/sites/index.php
+++ b/management/sites/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,56 +26,56 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Site Management | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
 	<link rel="stylesheet" href="/dist/management/sites/sites.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -118,14 +118,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/sites/sites.js"></script>

--- a/management/users/index.php
+++ b/management/users/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,55 +26,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>User Management | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/management/users/users.css" />
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -198,14 +198,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/users/users.js"></script>

--- a/profile/index.php
+++ b/profile/index.php
@@ -15,7 +15,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -26,55 +26,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Profile | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/profile/profile.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -204,14 +204,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/profile/profile.js"></script>

--- a/questionnaire/index.php
+++ b/questionnaire/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,56 +20,56 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Questionnaire | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
 	<link rel="stylesheet" href="/dist/questionnaire/questionnaire.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -113,14 +113,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/questionnaire/questionnaire.js"></script>

--- a/queue/index.php
+++ b/queue/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,56 +20,56 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Queue | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/queue/queue.css">
 	<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.4/angular-material.min.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -111,14 +111,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <?php

--- a/register/index.php
+++ b/register/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Register | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<!-- Place optional header elements here -->
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -171,14 +171,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/register/register.js"></script>

--- a/signup/index.php
+++ b/signup/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,7 +20,7 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Sign Up for a VITA Appointment | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/assets/css/form.css">
 	<link rel="stylesheet" href="/dist/assets/css/printAppointmentConfirmation.css">
@@ -28,49 +28,49 @@ return readfile($documentRoot . $path);
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -113,14 +113,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/signup/signup.js"></script>

--- a/unauthorized/index.php
+++ b/unauthorized/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at http://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Unauthorized | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<link rel="stylesheet" href="/dist/error_pages/error_page.css">
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -115,14 +115,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->

--- a/volunteer/index.php
+++ b/volunteer/index.php
@@ -9,7 +9,7 @@ return readfile($documentRoot . $path);
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-1.html"); ?>
 	<!--
 		Membership and regular participation in the UNL Web Developer Network is required to use the UNLedu Web Framework. Visit the WDN site at https://wdn.unl.edu/. Register for our mailing list and add your site or server to UNLwebaudit.
 		All framework code is the property of the UNL Web Developer Network. The code seen in a source code view is not, and may not be used as, a template. You may not use this code, a reverse-engineered version of this code, or its associated visual presentation in whole or in part to create a derivative work.
@@ -20,55 +20,55 @@ return readfile($documentRoot . $path);
 	<!-- TemplateBeginEditable name="doctitle" -->
 	<title>Volunteer | VITA Lincoln | University of Nebraska&ndash;Lincoln</title>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/head-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/head-2.html"); ?>
 	<!-- TemplateBeginEditable name="head" -->
 	<!-- Place optional header elements here -->
 	<!-- TemplateEndEditable -->
 	<!-- TemplateParam name="class" type="text" value="" -->
 </head>
-<body class="@@(_document['class'])@@ unl" data-version="5.0">
-<?php wdnInclude("/wdn/templates_5.0/includes/global/skip-nav.html"); ?>
+<body class="@@(_document['class'])@@ unl" data-version="5.1">
+<?php wdnInclude("/wdn/templates_5.1/includes/global/skip-nav.html"); ?>
 <header class="dcf-header" id="dcf-header" role="banner">
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-1.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="visitlocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/visit-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/visit-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/visit-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/visit-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="applylocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/apply-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/apply-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/apply-global-2.html"); ?>
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/apply-global-2.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-1.html"); ?>
 				<!-- TemplateBeginEditable name="givelocal" -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/local/give-local.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/local/give-local.html"); ?>
 				<!-- TemplateEndEditable -->
-				<?php wdnInclude("/wdn/templates_5.0/includes/global/give-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/search.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/header-global-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-1.html"); ?>
+				<?php wdnInclude("/wdn/templates_5.1/includes/global/give-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/search.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/header-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-1.html"); ?>
 	<!-- TemplateBeginEditable name="affiliation" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-affiliation-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-affiliation-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-1.html"); ?>
 	<!-- TemplateBeginEditable name="titlegraphic" -->
 	<a class="unl-site-title-medium" href="/">VITA Lincoln</a>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/site-title-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/logo-lockup-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-group.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-1.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-toggle-btn.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/site-title-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/logo-lockup-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-group.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-toggle-btn.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-1.html"); ?>
 	<!-- TemplateBeginEditable name="navlinks" -->
 		<?php include "$root/sharedcode/navigation.php"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-child-2.html"); ?>
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/nav-menu-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-child-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/nav-menu-2.html"); ?>
 </header>
 
 <main class="dcf-main" id="dcf-main" role="main" tabindex="-1">
@@ -114,14 +114,14 @@ return readfile($documentRoot . $path);
 <footer class="dcf-footer" id="dcf-footer" role="contentinfo">
 	<!-- TemplateBeginEditable name="optionalfooter" -->
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-1.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-1.html"); ?>
 	<!-- TemplateBeginEditable name="contactinfo" -->
 		<?php include "$root/sharedcode/localFooter.html"; ?>
 	<!-- TemplateEndEditable -->
-		<?php wdnInclude("/wdn/templates_5.0/includes/global/footer-global-2.html"); ?>
+		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/noscript.html"); ?>
-<?php wdnInclude("/wdn/templates_5.0/includes/global/js-body.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
+<?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <!-- put your custom javascript here -->


### PR DESCRIPTION
Bumped the UNL Framework version to 5.1 so the UNL Web Audit wouldn't complain anymore.

In retrospect, maybe we should've including the `/wdn/templates_5.1` part in the `wdnInclude` method so it doesn't require 690 line changes next time we have to bump this version haha