### PR TITLE
Verify Changes to Fillable Forms

### DIFF
--- a/server/appointment/upload-documents/uploadDocuments.php
+++ b/server/appointment/upload-documents/uploadDocuments.php
@@ -186,10 +186,10 @@ function validateForm14446HasChanged($uploadedFileTempName) {
 
 	$uploadedFileContentAsString = file_get_contents($uploadedFileTempName);
 	$uploadedFileHash = md5($uploadedFileContentAsString);
-	$expectedFileContentAsString = file_get_contents("$root/server/download/documents/f14446VirtualLincolnVita.pdf");
-	$expectedFileHash = md5($expectedFileContentAsString);
+	$originalFileContentAsString = file_get_contents("$root/server/download/documents/f14446VirtualLincolnVita.pdf");
+	$originalFileHash = md5($originalFileContentAsString);
 
-	if ($uploadedFileHash === $expectedFileHash) {
+	if ($uploadedFileHash === $originalFileHash) {
 		throw new Exception('Error: The uploaded Form 14446 does not appear to have been changed. Verify your changes and then save the file to your system and re-upload the file.', MY_EXCEPTION);
 	}
 }
@@ -199,10 +199,10 @@ function validateForm13614CHasChanged($uploadedFileTempName) {
 
 	$uploadedFileContentAsString = file_get_contents($uploadedFileTempName);
 	$uploadedFileHash = md5($uploadedFileContentAsString);
-	$expectedFileContentAsString = file_get_contents("$root/server/download/documents/IntakeForm_13614C.pdf");
-	$expectedFileHash = md5($expectedFileContentAsString);
+	$originalFileContentAsString = file_get_contents("$root/server/download/documents/IntakeForm_13614C.pdf");
+	$originalFileHash = md5($originalFileContentAsString);
 
-	if ($uploadedFileHash === $expectedFileHash) {
+	if ($uploadedFileHash === $originalFileHash) {
 		throw new Exception('Error: The uploaded Intake Form 13614-C does not appear to have been changed. Verify your changes and then save the file to your system and re-upload the file.', MY_EXCEPTION);
 	}
 }

--- a/server/appointment/upload-documents/uploadDocuments.php
+++ b/server/appointment/upload-documents/uploadDocuments.php
@@ -107,6 +107,16 @@ function uploadDocument($token, $firstName, $lastName, $emailAddress, $phoneNumb
 		if ($uploadedFileErrorCode !== 0) {
 			throw new Exception('Error uploading file', MY_EXCEPTION);
 		}
+
+		// Check if file is Fillable Form 14446 and, if so, that it has changed
+		if (preg_match('/(.*)f14446VirtualLincolnVita(.*)\.pdf(.*)/i', $uploadedFileName)) {
+			validateForm14446HasChanged($uploadedFileTempName);
+		}
+
+		// Check if file is Fillable Intake Form 13614C and, if so, that it has changed
+		if (preg_match('/(.*)IntakeForm_13614C(.*)\.pdf(.*)/i', $uploadedFileName)) {
+			validateForm13614CHasChanged($uploadedFileTempName);
+		}
 		
 		// Validate the client information
 		$clientInformation = validateClientInformation($token, $firstName, $lastName, $emailAddress, $phoneNumber);
@@ -170,6 +180,32 @@ function markAppointmentAsReady($token, $firstName, $lastName, $emailAddress, $p
 /* 
  * Private functions
  */
+
+function validateForm14446HasChanged($uploadedFileTempName) {
+	GLOBAL $root;
+
+	$uploadedFileContentAsString = file_get_contents($uploadedFileTempName);
+	$uploadedFileHash = md5($uploadedFileContentAsString);
+	$expectedFileContentAsString = file_get_contents("$root/server/download/documents/f14446VirtualLincolnVita.pdf");
+	$expectedFileHash = md5($expectedFileContentAsString);
+
+	if ($uploadedFileHash === $expectedFileHash) {
+		throw new Exception('Error: The uploaded Form 14446 does not appear to have been changed. Verify your changes and then save the file to your system and re-upload the file.', MY_EXCEPTION);
+	}
+}
+
+function validateForm13614CHasChanged($uploadedFileTempName) {
+	GLOBAL $root;
+
+	$uploadedFileContentAsString = file_get_contents($uploadedFileTempName);
+	$uploadedFileHash = md5($uploadedFileContentAsString);
+	$expectedFileContentAsString = file_get_contents("$root/server/download/documents/IntakeForm_13614C.pdf");
+	$expectedFileHash = md5($expectedFileContentAsString);
+
+	if ($uploadedFileHash === $expectedFileHash) {
+		throw new Exception('Error: The uploaded Intake Form 13614-C does not appear to have been changed. Verify your changes and then save the file to your system and re-upload the file.', MY_EXCEPTION);
+	}
+}
 
 function validateClientInformation($token, $firstName, $lastName, $emailAddress, $phoneNumber) {
 	$clientInformation = getClientInformationFromToken($token);

--- a/signup/signup.php
+++ b/signup/signup.php
@@ -299,7 +299,7 @@
 
 			<div class="dcf-input-checkbox">
 				<input id="agree-to-virtual-preparation-checkbox" type="checkbox" ng-model="agreeToVirtualPreparationCheckbox.checked" value="false">
-				<label for="agree-to-virtual-preparation-checkbox">I agree to have my tax return prepared virtually. See <a href="https://www.irs.gov/pub/irs-pdf/f14446.pdf" target="_blank">Form 14446 (Virtual VITA/TCE Taxpayer Consent)</a></label>
+				<label for="agree-to-virtual-preparation-checkbox">I agree to have my tax return prepared virtually. See <a href ng-click="downloadForm14446()">Form 14446 (Virtual VITA/TCE Taxpayer Consent)</a></label>
 			</div>
 
 			<input type="submit" 

--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -167,6 +167,20 @@ define('signupController', [], function() {
 			}
 		};
 
+		$scope.downloadForm14446 = () => {
+			const fileUrl = '/server/download/downloadForm14446VirtualAppt.php';
+			let iframe = document.getElementById('hiddenDownloader');
+			if (iframe == null) {
+				iframe = document.createElement('iframe');
+				iframe.id = 'hiddenDownloader';
+				iframe.style.visibility = 'hidden';
+				iframe.style.display = 'none';
+				document.body.appendChild(iframe);
+			}
+		
+			iframe.src = fileUrl;
+		};
+
 	}
 
 	signupController.$inject = ['$scope', '$sce', 'signupDataService', 'appointmentPickerSharedPropertiesService', 'notificationUtilities'];


### PR DESCRIPTION
Katie had noticed that many clients who were uploading the fillable documents (Form 14446 and Form 13614-C) were uploaded blank files. This is likely because the client didn't save the document after editing it (possibly in browser). This PR hopefully addresses these issues by raising an error if a user tries to upload either of those forms and they don't appear to have changed from the version provided to them by the server. To accomplish this, we simply MD5 hash their file and the file on the server, if the hash is the same, then the uploaded file hasn't been changed, and we reject it. 