### PR TITLE
Remove URL Encoding of File Name for BLOB Storage

### DIFF
--- a/server/appointment/upload-documents/uploadDocuments.php
+++ b/server/appointment/upload-documents/uploadDocuments.php
@@ -125,7 +125,7 @@ function uploadDocument($token, $firstName, $lastName, $emailAddress, $phoneNumb
 		// Upload the user's file to Azure BLOB Storage
 		$containerName = 'ty2019';
 		$fileContent = fopen($uploadedFileTempName, 'r');
-		$fileNameToSave = urlencode($firstName.'_'.$lastName)."/$appointmentId/".uniqid().urlencode("-$uploadedFileName");
+		$fileNameToSave = $firstName.'_'.$lastName."/$appointmentId/".uniqid()."-$uploadedFileName";
 
 		$blobClient = BlobRestProxy::createBlobService(AZURE_BLOB_STORAGE_CONNECTION_STRING);
 		$blobClient->createBlockBlob($containerName, $fileNameToSave, $fileContent);


### PR DESCRIPTION
This was an issue identified after some files were uploaded to the BLOB storage. The BLOB storage stores literal names, so when we were URL encoding them (for example) "[" turned into "%5B" and "]" turned into "%5D", as expected. But the BLOB storage would literally store the file name containing the "%5B" and whatnot--so, when one went to hit the URL with their browser, the browser would convert it back to the un-encoded characters, and then the BLOB storage would say the file is not found. So, the fix here is to not url encode them (which is the right thing to do anyway with file names I think).