### PR TITLE
Email Input Required for Virtual Appointments

### DIFF
--- a/signup/signup.php
+++ b/signup/signup.php
@@ -42,9 +42,12 @@
 				</li>
 
 				<li class="form-textfield">
-					<label class="dcf-label form-label" for="email">Email</label>
-					<input type="email" class="dcf-input-text form-control" name="email" id="email" ng-model="data.email">
-					<p class="dcf-txt-xs">A confirmation email will be sent to this email address.</p>
+					<label class="dcf-label form-label" ng-class="{ 'form-required': isEmailRequired() }" for="email">Email</label>
+					<input type="email" class="dcf-input-text form-control" name="email" id="email" ng-model="data.email" ng-required="isEmailRequired()">
+					<div ng-show="form.$submitted || form.email.$touched">
+						<label class="error" ng-show="form.email.$error.required">This field is required for virtual appointments.</label>
+					</div>
+					<p class="dcf-txt-xs">A confirmation email will be sent to this email address. This field is required if you are scheduling a virtual appointment.</p>
 				</li>
 
 				<li class="form-textfield">
@@ -302,6 +305,8 @@
 				<input id="agree-to-virtual-preparation-checkbox" type="checkbox" ng-model="agreeToVirtualPreparationCheckbox.checked" value="false">
 				<label for="agree-to-virtual-preparation-checkbox">I agree to have my tax return prepared virtually. See <a href ng-click="downloadForm14446()">Form 14446 (Virtual VITA/TCE Taxpayer Consent)</a></label>
 			</div>
+
+			<p ng-if="form.$invalid && form.$submitted" class="error">Your input is invalid, please correct the errors above and re-submit this form</p>
 
 			<input type="submit" 
 				value="Submit" 

--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -168,7 +168,7 @@ define('signupController', [], function() {
 		};
 
 		$scope.isEmailRequired = () => {
-			return $scope.sharedProperties.isSelectedSiteVirtual == true;
+			return $scope.sharedProperties.isSelectedSiteVirtual === true;
 		};
 
 		$scope.downloadForm14446 = () => {

--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -167,6 +167,10 @@ define('signupController', [], function() {
 			}
 		};
 
+		$scope.isEmailRequired = () => {
+			return $scope.sharedProperties.isSelectedSiteVirtual == true;
+		};
+
 		$scope.downloadForm14446 = () => {
 			const fileUrl = '/server/download/downloadForm14446VirtualAppt.php';
 			let iframe = document.getElementById('hiddenDownloader');


### PR DESCRIPTION
Made the email input required for virtual appointments. This is a request from Katie--it's easier to reach out to clients via email rather than calling them for these virtual appointments.

Also added some text saying the form is invalid when the form is submitted and contains errors.