### PR TITLE
Appointment Questions Saving Bug Fix

### DIFF
--- a/signup/signupController.js
+++ b/signup/signupController.js
@@ -82,7 +82,7 @@ define('signupController', [], function() {
 				else if(country.treatyType === 'india') answerDatabaseId = "12";
 				else if(country.treatyType === 'treaty') answerDatabaseId = "13";
 				else if(country.treatyType === 'non-treaty') answerDatabaseId = "14";
-				
+
 				questions[indexOfCountryQuestionInQuestionsArray] = {
 					id: countryQuestionDatabaseId,
 					value: answerDatabaseId
@@ -158,6 +158,7 @@ define('signupController', [], function() {
 		};
 
 		$scope.residentialAppointment = function() {
+			$scope.questions[6] = null;
 			$scope.sharedProperties.appointmentType = 'residential';
 		};
 


### PR DESCRIPTION
Remove the country text question selection if the appointment is a residential appointment. 

This was discovered from a small bug where someone's appointment which should've been a residential (and was scheduled for a residential site) was for some reason appearing as a non-resident appointment. This PR addresses that issue by removing the country selection if the appointment is a residential appointment (similar to how we reset other questions when other options change)