### PR TITLE
Remove the Google Translate Feature

### DIFF
--- a/assets/css/printAppointmentConfirmation.css
+++ b/assets/css/printAppointmentConfirmation.css
@@ -3,7 +3,6 @@
 		size: portrait;
 	}
 
-	#google_translate_element, 
 	#wdn_menu_toggle, 
 	header, 
 	.dcf-logo-lockup,

--- a/components/translate.php
+++ b/components/translate.php
@@ -1,7 +1,0 @@
-<div id="google_translate_element" style="position: fixed; bottom: 0"></div>
-<script type="text/javascript">
-	function googleTranslateElementInit() {
-		new google.translate.TranslateElement({pageLanguage: 'en', includedLanguages: 'ar,es,en,vi', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
-	}
-</script>
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>

--- a/management/sites/index.php
+++ b/management/sites/index.php
@@ -124,12 +124,12 @@ return readfile($documentRoot . $path);
 	<!-- TemplateEndEditable -->
 		<?php wdnInclude("/wdn/templates_5.1/includes/global/footer-global-2.html"); ?>
 </footer>
+<script src="https://kit.fontawesome.com/f7ca51166c.js" crossorigin="anonymous"></script>
 <?php wdnInclude("/wdn/templates_5.1/includes/global/noscript.html"); ?>
 <?php wdnInclude("/wdn/templates_5.1/includes/global/js-body.html"); ?>
 <!-- TemplateBeginEditable name="jsbody" -->
 <?php require_once "$root/server/global_includes.php"; ?>
 <script src="/dist/management/sites/sites.js"></script>
-<script src="https://kit.fontawesome.com/f7ca51166c.js" crossorigin="anonymous"></script>
 <!-- TemplateEndEditable -->
 </body>
 </html>

--- a/server/global_includes.php
+++ b/server/global_includes.php
@@ -1,3 +1,4 @@
 <?php 
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
-require_once "$root/components/translate.php";
+// Any front-end PHP files that should be included on every page can be specified here
+


### PR DESCRIPTION
Katie and I were unsure if this was really used (or discoverable at all). Most browsers have this functionality built-in, so we decided we're probably safe to remove this.

I also moved a <script> tag containing the FontAwesome... there is some error with RequireJS that requires a JS file with an anonymous `define()` be loaded before RequireJS if you want it to work correctly, otherwise you get a nasty "define Mismatch error" in the console and FontAwesome just doesn't work. This is an issue in production currently, but since the only places we use FontAwesome are administrator stuff, I don't think it matters too much.