### PR TITLE
Cancelled appointments making queue look overbooked fix

### DIFF
--- a/components/appointmentPicker/appointmentPickerDataService.js
+++ b/components/appointmentPicker/appointmentPickerDataService.js
@@ -3,8 +3,9 @@ define('appointmentPickerDataService', [], function($http) {
 	function appointmentPickerDataService($http) {
 		return {
 			loadAllAppointments: function(year, appointmentType = "residential") {
+				// Is this able to call anything? I only see getAppointmentTimes in getTimes.php
 				return $http.get(`/server/api/appointments/getTimes.php?action=getAppointments&year=${year}&appointmentType=${appointmentType}`).then(function(response){
-					return response.data;
+					return response.data; 
 				},function(error){
 					return null;
 				});

--- a/components/appointmentPicker/appointmentPickerDataService.js
+++ b/components/appointmentPicker/appointmentPickerDataService.js
@@ -3,8 +3,7 @@ define('appointmentPickerDataService', [], function($http) {
 	function appointmentPickerDataService($http) {
 		return {
 			loadAllAppointments: function(year, appointmentType = "residential") {
-				// Is this able to call anything? I only see getAppointmentTimes in getTimes.php
-				return $http.get(`/server/api/appointments/getTimes.php?action=getAppointments&year=${year}&appointmentType=${appointmentType}`).then(function(response){
+				return $http.get(`/server/api/appointments/getTimes.php?year=${year}&appointmentType=${appointmentType}`).then(function(response){
 					return response.data; 
 				},function(error){
 					return null;

--- a/server/api/appointments/getTimes.php
+++ b/server/api/appointments/getTimes.php
@@ -111,5 +111,3 @@ class DateSiteTimeMap {
 		}
 	}
 }
-
-

--- a/server/management/sites/sites.php
+++ b/server/management/sites/sites.php
@@ -82,7 +82,9 @@ function getAppointmentTimesForSite($siteId, $year = null) {
 		FROM AppointmentTime
 		JOIN AppointmentType ON AppointmentTime.appointmentTypeId = AppointmentType.appointmentTypeId
 		LEFT JOIN Appointment ON AppointmentTime.appointmentTimeId = Appointment.appointmentTimeId
+        LEFT JOIN ServicedAppointment ON Appointment.appointmentId = ServicedAppointment.appointmentId
 		WHERE siteId = ?
+			AND (cancelled IS NULL OR cancelled = FALSE)
 			AND YEAR(scheduledTime) = ?
 		GROUP BY AppointmentTime.appointmentTimeId
 		ORDER BY AppointmentTime.scheduledTime;';


### PR DESCRIPTION
This PR is pretty straightforward--we don't want to include cancelled appointments when calculating the number of appointments already scheduled. However, I do have one question:

After I wrote the query, I poked around to see how other pages got their appointments from the DB, and I found `appointmentDataPickerService.js` calls `/server/api/appointments/getTimes.php?action=getAppointments&...`, but there is only `getAppointmentTimes` in `getTimes.php`. `getAppointmentTimes` still uses the parameters passed by the service call (`year` and `appointmentType`, but how does this work? `getTimes.php` doesn't have the conventional switch statement, so is `getAppointmentTimes` on line 11 just called irrespective of the function included in the data service's `$http.get` string?

Either way, this function actually looks like it has the same cancel check as I included in `sites.php`. The same is true for `getAppointments` in `/server/queue/queue.php`.

Both `queue.php` and `/server/management/appointments/appointments.php` have a `getAppointments` function in its switch statement--my guess is the code for `getAppointmentTimes` in `getTimes.php` was copied over to `getTimes.php`, or the function was renamed.

Unlike `queue.php` and `getTimes.php`, in `appointments.php` the cancelled status of the appointment is not filtered on, which is good--admins should still be able to see cancelled appointments on that page. All that is to say I don't think this change in `sites.php` will have any unintended consequences.