### PR TITLE
Login quickfix -- pulling to assign to issue

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
 function wdnInclude($path)
 {
 $documentRoot = 'https://unlcms.unl.edu';

--- a/index.template.5.php
+++ b/index.template.5.php
@@ -1,5 +1,7 @@
 <?php
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
 function wdnInclude($path)
 {
 $documentRoot = 'https://unlcms.unl.edu';

--- a/questionnaire/index.php
+++ b/questionnaire/index.php
@@ -1,5 +1,7 @@
 <?php
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
 function wdnInclude($path)
 {
 $documentRoot = 'https://unlcms.unl.edu';

--- a/signup/index.php
+++ b/signup/index.php
@@ -1,5 +1,7 @@
 <?php
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
 function wdnInclude($path)
 {
 $documentRoot = 'https://unlcms.unl.edu';

--- a/volunteer/index.php
+++ b/volunteer/index.php
@@ -105,7 +105,19 @@ return readfile($documentRoot . $path);
 		<!-- TemplateBeginEditable name="maincontentarea" -->
 		<div class="dcf-bleed">
 			<div class="dcf-wrapper dcf-pb-8">
-				<p>This page isn't quite ready. Check back later for updates!</p>
+			<p>Children living in poverty need your help. The American Rescue Plan of 2021 has increased the dollar amount of
+			 child tax credits and set the income limit to $0. There are 38,000 non-filers in Nebraska which include 9.600
+			 households and 11,000 children under the age of 17. By becoming an IRS certified return preparer or greeter,
+			 you are assisting our low income working families in filing their 2021 federal and state income tax returns
+			 for free. More importantly you are assuring our children will receive their child tax credits and earned
+			 income credits.
+			<br>
+			<br>  
+			Start today, by <a href="https://www.givepulse.com/event/244585">registering.</a>
+			<br>
+			Training information and volunteer activities are forthcoming.
+			</p>
+
 			</div>
 		</div>
 		<!-- TemplateEndEditable -->

--- a/volunteer/index.php
+++ b/volunteer/index.php
@@ -1,5 +1,7 @@
 <?php
 $root = realpath($_SERVER["DOCUMENT_ROOT"]);
+require_once "$root/server/user.class.php";
+$USER = new User();
 function wdnInclude($path)
 {
 $documentRoot = 'https://unlcms.unl.edu';


### PR DESCRIPTION
Do these two lines just need to be added to every index.php that should recognize a login status?

For instance, even if I resolve the problem on this page, if I then go to the questionnaire while logged in, it will only show the limited navigation bar. Adding these two lines and hard refreshing the questionnaire rendered the full navigation bar.